### PR TITLE
Migrate to Cloudflare Workers + D1 (webhook Telegram bot)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-worker
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Typecheck, test and deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npx vitest run
+
+      # Schema first: the Worker deployed below expects the migrated tables.
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply iou-app --remote
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,13 @@ db_data/
 *.json
 .ruff_cache/
 .op/
+
+# Cloudflare Worker (TypeScript)
+node_modules/
+.wrangler/
+worker-configuration.d.ts
+test/generated/*.mjs
+# The blanket *.json rule above predates the Worker; these are source.
+!package.json
+!package-lock.json
+!tsconfig.json

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,26 @@
+-- Migration number: 0001 	 initial schema
+
+CREATE TABLE users (
+  username TEXT PRIMARY KEY,
+  conversation_id TEXT,
+  telegram_user_id INTEGER UNIQUE
+);
+
+CREATE TABLE entries (
+  id TEXT PRIMARY KEY,              -- uuid4 string, legacy ids preserved
+  created_at TEXT NOT NULL,         -- 'YYYY-MM-DD HH:MM:SS' (legacy format kept; new rows use same format, UTC)
+  conversation_id TEXT,             -- telegram chat id where created (kept for parity)
+  sender TEXT NOT NULL,             -- username, no leading @
+  recipient TEXT NOT NULL,
+  amount REAL NOT NULL,             -- legacy stored strings; cast to REAL
+  description TEXT,
+  deleted INTEGER NOT NULL DEFAULT 0,
+  deleted_at TEXT
+);
+CREATE INDEX idx_entries_sender ON entries(sender);
+CREATE INDEX idx_entries_recipient ON entries(recipient);
+
+CREATE TABLE sessions (             -- grammY session/conversation storage adapter
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4174 @@
+{
+  "name": "iou-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "iou-app",
+      "version": "1.0.0",
+      "dependencies": {
+        "@grammyjs/conversations": "^2.1.1",
+        "grammy": "^1.45.1"
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.20.3",
+        "@cloudflare/workers-types": "^5.20260809.1",
+        "esbuild": "^0.28.2",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10",
+        "wrangler": "^4.120.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.20.3.tgz",
+      "integrity": "sha512-aCMvM5zQ3MTz8SorSZB6ZxjVK2Gof6UhIc2Z1z9zbX/obucSYwDUkx8A0MUOod4I7clfB0QLarKBjRdIczK3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260801.1-alpha",
+        "wrangler": "4.120.0",
+        "zod": "4.4.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260801.1.tgz",
+      "integrity": "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260801.1.tgz",
+      "integrity": "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260801.1.tgz",
+      "integrity": "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260801.1.tgz",
+      "integrity": "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260801.1.tgz",
+      "integrity": "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260809.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260809.1.tgz",
+      "integrity": "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grammyjs/conversations": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@grammyjs/conversations/-/conversations-2.1.1.tgz",
+      "integrity": "sha512-hoxqwSkaXDeU7mzXulpk3A4Cmd6UZO3HU4aPoITX5ekSHK7ZcUEmMl7RhKKkqw3z6zVbbAShQreJoVV5/dDSLA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.20.1"
+      }
+    },
+    "node_modules/@grammyjs/types": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-4.0.0.tgz",
+      "integrity": "sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==",
+      "license": "MIT"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/grammy": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.45.1.tgz",
+      "integrity": "sha512-Y4VL/hqJMZZxwlUr5ZgM68CFu2iIeEkNLR1cY3+Ww68CIvWARDsoXFix7+31rmyC0+7L85ZI+Pq3E5JSG5+nLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "4.0.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260801.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260801.1-alpha.tgz",
+      "integrity": "sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260801.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260801.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260801.1.tgz",
+      "integrity": "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260801.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260801.1",
+        "@cloudflare/workerd-linux-64": "1.20260801.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260801.1",
+        "@cloudflare/workerd-windows-64": "1.20260801.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.120.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.120.0.tgz",
+      "integrity": "sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260801.1-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260801.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260801.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "iou-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@grammyjs/conversations": "^2.1.1",
+    "grammy": "^1.45.1"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.20.3",
+    "@cloudflare/workers-types": "^5.20260809.1",
+    "esbuild": "^0.28.2",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10",
+    "wrangler": "^4.120.0"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iou_app"
-version = "0.13.10"
+version = "1.0.0"
 description = "IOU App"
 authors = ["Skyler Carlson"]
 packages = [

--- a/test/amount.test.ts
+++ b/test/amount.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { AmountError, validateAmountStr } from '../worker/domain/amount.js';
+import { formatMoney, formatMoneyPlain, round2 } from '../worker/domain/money.js';
+
+describe('validateAmountStr', () => {
+  it('accepts plain decimals', () => {
+    expect(validateAmountStr('21.5')).toBe(21.5);
+    expect(validateAmountStr('7')).toBe(7);
+    expect(validateAmountStr('.5')).toBe(0.5);
+    expect(validateAmountStr('1.')).toBe(1);
+  });
+
+  it('strips currency symbols and thousands separators', () => {
+    expect(validateAmountStr('$1,234.50')).toBe(1234.5);
+    expect(validateAmountStr('  $42  ')).toBe(42);
+    expect(validateAmountStr('+5')).toBe(5);
+  });
+
+  it('rejects anything containing letters', () => {
+    for (const input of ['12abc', 'abc', 'ten', '1e5', 'inf', 'nan', '5 USD']) {
+      expect(() => validateAmountStr(input)).toThrow(AmountError);
+    }
+    expect(() => validateAmountStr('12abc')).toThrow(/contains invalid characters/);
+  });
+
+  it('rejects unparseable numbers', () => {
+    for (const input of ['12.34.56', '1-2', '--1', '.', '-', '', '$', ',,,']) {
+      expect(() => validateAmountStr(input)).toThrow(AmountError);
+    }
+    expect(() => validateAmountStr('12.34.56')).toThrow(/Unable to parse amount/);
+  });
+
+  it('rejects non-positive amounts', () => {
+    for (const input of ['0', '0.00', '-5', '-0.01']) {
+      expect(() => validateAmountStr(input)).toThrow(/must be positive/);
+    }
+  });
+});
+
+describe('money formatting', () => {
+  it('breaks exact ties to even, like Python round()', () => {
+    expect(round2(0.125)).toBe(0.12);
+    expect(round2(0.135)).toBe(0.14);
+    // 1.005 is below the tie in binary, so Python rounds it down too.
+    expect(round2(1.005)).toBe(1);
+  });
+
+  it('renders amounts the way the legacy bot did', () => {
+    expect(formatMoney(1234.5)).toBe('$1,234.50');
+    expect(formatMoney(7)).toBe('$7.00');
+    expect(formatMoney(3.3333333333333335)).toBe('$3.33');
+    expect(formatMoneyPlain(1234.5)).toBe('$1234.50');
+  });
+});

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,154 @@
+import { env } from 'cloudflare:test';
+import { Bot } from 'grammy';
+import type { Update, UserFromGetMe } from 'grammy/types';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { authorize } from '../worker/bot/auth.js';
+import { GENERIC_ERROR, UNAUTHORIZED, UNAUTHORIZED_CALLBACK } from '../worker/bot/strings.js';
+import { getUserByUsername } from '../worker/db/users.js';
+import type { BotContext } from '../worker/types.js';
+
+const BOT_INFO = {
+  id: 42,
+  is_bot: true,
+  first_name: 'IOU',
+  username: 'iou_test_bot',
+  can_join_groups: true,
+  can_read_all_group_messages: false,
+  supports_inline_queries: false,
+} as UserFromGetMe;
+
+interface ApiCall {
+  method: string;
+  payload: Record<string, unknown>;
+}
+
+/** A bot whose outgoing API calls are captured instead of sent to Telegram. */
+function buildBot() {
+  const calls: ApiCall[] = [];
+  const reached: string[] = [];
+
+  const bot = new Bot<BotContext>('123456:test-token', { botInfo: BOT_INFO });
+  bot.api.config.use(async (_prev, method, payload) => {
+    calls.push({ method, payload: payload as Record<string, unknown> });
+    return { ok: true, result: true } as never;
+  });
+
+  bot.use(authorize(env));
+  bot.command('hello', async (ctx) => {
+    reached.push(ctx.iouUser.username);
+    await ctx.reply('Hello to yourself!');
+  });
+  bot.on('callback_query:data', async (ctx) => {
+    reached.push(ctx.iouUser.username);
+    await ctx.answerCallbackQuery();
+  });
+
+  return { bot, calls, reached };
+}
+
+function messageUpdate(from: { id: number; username?: string }): Update {
+  return {
+    update_id: 1,
+    message: {
+      message_id: 1,
+      date: 1_700_000_000,
+      chat: { id: 500, type: 'private', first_name: 'Test' },
+      from: { id: from.id, is_bot: false, first_name: 'Test', username: from.username },
+      text: '/hello',
+      entities: [{ type: 'bot_command', offset: 0, length: 6 }],
+    },
+  } as Update;
+}
+
+function callbackUpdate(from: { id: number; username?: string }): Update {
+  return {
+    update_id: 2,
+    callback_query: {
+      id: 'cb1',
+      chat_instance: 'ci',
+      data: 'SEND_RECIPIENT_bob',
+      from: { id: from.id, is_bot: false, first_name: 'Test', username: from.username },
+    },
+  } as Update;
+}
+
+beforeEach(async () => {
+  await env.DB.prepare('DELETE FROM users').run();
+  await env.DB.batch([
+    env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('alice', '500', null),
+    env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('bob', '600', 600),
+  ]);
+});
+
+describe('allowlist gating', () => {
+  it('lets an allowlisted user through to the handler', async () => {
+    const { bot, calls, reached } = buildBot();
+    await bot.handleUpdate(messageUpdate({ id: 100, username: 'alice' }));
+
+    expect(reached).toEqual(['alice']);
+    expect(calls[0]?.payload.text).toBe('Hello to yourself!');
+  });
+
+  it('refuses a user who is not in the users table', async () => {
+    const { bot, calls, reached } = buildBot();
+    await bot.handleUpdate(messageUpdate({ id: 999, username: 'mallory' }));
+
+    expect(reached).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe('sendMessage');
+    expect(calls[0]?.payload.text).toBe(UNAUTHORIZED);
+  });
+
+  it('refuses a user with no Telegram username', async () => {
+    const { bot, calls, reached } = buildBot();
+    await bot.handleUpdate(messageUpdate({ id: 999 }));
+
+    expect(reached).toEqual([]);
+    expect(calls[0]?.payload.text).toBe('You must have a Telegram username to use this bot.');
+  });
+
+  it('refuses an unauthorized callback query with an alert, not a chat message', async () => {
+    const { bot, calls, reached } = buildBot();
+    await bot.handleUpdate(callbackUpdate({ id: 999, username: 'mallory' }));
+
+    expect(reached).toEqual([]);
+    expect(calls[0]?.method).toBe('answerCallbackQuery');
+    expect(calls[0]?.payload.text).toBe(UNAUTHORIZED_CALLBACK);
+    expect(calls[0]?.payload.show_alert).toBe(true);
+  });
+
+  it('backfills the numeric Telegram id the first time a user is seen', async () => {
+    const { bot } = buildBot();
+    await bot.handleUpdate(messageUpdate({ id: 100, username: 'alice' }));
+
+    const alice = await getUserByUsername(env.DB, 'alice');
+    expect(alice?.telegram_user_id).toBe(100);
+  });
+
+  it('matches on the numeric id even after a username change', async () => {
+    const { bot, reached } = buildBot();
+    await bot.handleUpdate(messageUpdate({ id: 600, username: 'bob_renamed' }));
+
+    expect(reached).toEqual(['bob']);
+  });
+
+  it('does not let an impostor claim an allowlisted username already bound to another id', async () => {
+    const { bot, calls, reached } = buildBot();
+    await bot.handleUpdate(messageUpdate({ id: 777, username: 'bob' }));
+
+    expect(reached).toEqual([]);
+    expect(calls[0]?.payload.text).toBe(UNAUTHORIZED);
+    const bob = await getUserByUsername(env.DB, 'bob');
+    expect(bob?.telegram_user_id).toBe(600);
+  });
+
+  it('fails closed when the database is unreachable', async () => {
+    const { bot, calls, reached } = buildBot();
+    await env.DB.prepare('DROP TABLE users').run();
+
+    await bot.handleUpdate(messageUpdate({ id: 100, username: 'alice' }));
+
+    expect(reached).toEqual([]);
+    expect(calls[0]?.payload.text).toBe(GENERIC_ERROR);
+  });
+});

--- a/test/balance.test.ts
+++ b/test/balance.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { computeIouStatus } from '../worker/domain/balance.js';
+
+const entry = (sender: string, recipient: string, amount: number) => ({
+  sender,
+  recipient,
+  amount,
+});
+
+describe('computeIouStatus', () => {
+  it('reports a zero balance in the queried order when there is nothing outstanding', () => {
+    expect(computeIouStatus([], 'alice', 'bob')).toEqual({
+      owingUser: 'alice',
+      owedUser: 'bob',
+      amount: 0,
+    });
+  });
+
+  it('nets entries in both directions', () => {
+    const entries = [
+      entry('alice', 'bob', 30),
+      entry('alice', 'bob', 12.5),
+      entry('bob', 'alice', 10),
+    ];
+    expect(computeIouStatus(entries, 'alice', 'bob')).toEqual({
+      owingUser: 'alice',
+      owedUser: 'bob',
+      amount: 32.5,
+    });
+  });
+
+  it('flips the direction when the net is negative', () => {
+    const entries = [entry('alice', 'bob', 5), entry('bob', 'alice', 20)];
+    expect(computeIouStatus(entries, 'alice', 'bob')).toEqual({
+      owingUser: 'bob',
+      owedUser: 'alice',
+      amount: 15,
+    });
+  });
+
+  it('is symmetric under swapping the two users', () => {
+    const entries = [entry('alice', 'bob', 5), entry('bob', 'alice', 20)];
+    expect(computeIouStatus(entries, 'bob', 'alice')).toEqual({
+      owingUser: 'bob',
+      owedUser: 'alice',
+      amount: 15,
+    });
+  });
+
+  it('reports an exactly cancelled balance as zero', () => {
+    const entries = [entry('alice', 'bob', 40), entry('bob', 'alice', 40)];
+    expect(computeIouStatus(entries, 'alice', 'bob').amount).toBe(0);
+  });
+
+  it('ignores entries involving other people', () => {
+    const entries = [
+      entry('alice', 'bob', 10),
+      entry('alice', 'carol', 999),
+      entry('carol', 'bob', 999),
+    ];
+    expect(computeIouStatus(entries, 'alice', 'bob').amount).toBe(10);
+  });
+
+  it('rounds float tails to 2dp for display without touching the stored values', () => {
+    const entries = [
+      entry('alice', 'bob', 3.3333333333333335),
+      entry('alice', 'bob', 3.3333333333333335),
+      entry('alice', 'bob', 3.3333333333333335),
+    ];
+    expect(computeIouStatus(entries, 'alice', 'bob').amount).toBe(10);
+  });
+});

--- a/test/botEntry.ts
+++ b/test/botEntry.ts
@@ -1,0 +1,1 @@
+export { createBot } from '../worker/bot/index.js';

--- a/test/botEntry.ts
+++ b/test/botEntry.ts
@@ -1,1 +1,2 @@
 export { createBot } from '../worker/bot/index.js';
+export { default as worker } from '../worker/index.js';

--- a/test/entries.test.ts
+++ b/test/entries.test.ts
@@ -1,0 +1,113 @@
+import { env } from 'cloudflare:test';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  addEntries,
+  addEntry,
+  getActiveEntriesBetween,
+  getActiveEntriesForUser,
+  settleBetween,
+} from '../worker/db/entries.js';
+import { computeIouStatus } from '../worker/domain/balance.js';
+
+async function seed(sender: string, recipient: string, amount: number): Promise<void> {
+  await addEntry(env.DB, {
+    conversationId: '1',
+    sender,
+    recipient,
+    amount,
+    description: `${sender}->${recipient}`,
+  });
+}
+
+beforeEach(async () => {
+  await env.DB.prepare('DELETE FROM entries').run();
+});
+
+describe('entries in D1', () => {
+  it('round-trips an entry as an active row', async () => {
+    await seed('alice', 'bob', 21.5);
+    const rows = await getActiveEntriesBetween(env.DB, 'alice', 'bob');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.amount).toBe(21.5);
+    expect(rows[0]?.deleted).toBe(0);
+    expect(rows[0]?.created_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('matches entries between two users in either direction', async () => {
+    await seed('alice', 'bob', 10);
+    await seed('bob', 'alice', 4);
+    await seed('alice', 'carol', 99);
+
+    const rows = await getActiveEntriesBetween(env.DB, 'alice', 'bob');
+    expect(rows).toHaveLength(2);
+    expect(computeIouStatus(rows, 'alice', 'bob')).toEqual({
+      owingUser: 'alice',
+      owedUser: 'bob',
+      amount: 6,
+    });
+  });
+
+  it('lists every entry a user is party to', async () => {
+    await seed('alice', 'bob', 10);
+    await seed('carol', 'alice', 5);
+    await seed('bob', 'carol', 7);
+
+    const rows = await getActiveEntriesForUser(env.DB, 'alice');
+    expect(rows).toHaveLength(2);
+  });
+
+  it('writes all entries of a split together', async () => {
+    await addEntries(env.DB, [
+      { conversationId: '1', sender: 'bob', recipient: 'alice', amount: 20, description: 'a' },
+      { conversationId: '1', sender: 'carol', recipient: 'alice', amount: 20, description: 'a' },
+    ]);
+    expect(await getActiveEntriesForUser(env.DB, 'alice')).toHaveLength(2);
+  });
+
+  describe('settleBetween', () => {
+    it('soft-deletes every entry between the pair and reports the count', async () => {
+      await seed('alice', 'bob', 10);
+      await seed('bob', 'alice', 4);
+
+      const settled = await settleBetween(env.DB, 'alice', 'bob');
+      expect(settled).toBe(2);
+      expect(await getActiveEntriesBetween(env.DB, 'alice', 'bob')).toHaveLength(0);
+    });
+
+    it('keeps the history rather than deleting rows', async () => {
+      await seed('alice', 'bob', 10);
+      await settleBetween(env.DB, 'alice', 'bob');
+
+      const row = await env.DB.prepare(
+        'SELECT deleted, deleted_at FROM entries WHERE sender = ?',
+      )
+        .bind('alice')
+        .first<{ deleted: number; deleted_at: string | null }>();
+      expect(row?.deleted).toBe(1);
+      expect(row?.deleted_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    });
+
+    it('leaves other people’s entries untouched', async () => {
+      await seed('alice', 'bob', 10);
+      await seed('alice', 'carol', 10);
+
+      expect(await settleBetween(env.DB, 'alice', 'bob')).toBe(1);
+      expect(await getActiveEntriesBetween(env.DB, 'alice', 'carol')).toHaveLength(1);
+    });
+
+    it('settles nothing the second time around', async () => {
+      await seed('alice', 'bob', 10);
+      expect(await settleBetween(env.DB, 'alice', 'bob')).toBe(1);
+      expect(await settleBetween(env.DB, 'alice', 'bob')).toBe(0);
+    });
+
+    it('zeroes the balance', async () => {
+      await seed('alice', 'bob', 10);
+      await seed('bob', 'alice', 4);
+      await settleBetween(env.DB, 'alice', 'bob');
+
+      const rows = await getActiveEntriesBetween(env.DB, 'alice', 'bob');
+      expect(computeIouStatus(rows, 'alice', 'bob').amount).toBe(0);
+    });
+  });
+});

--- a/test/env.d.ts
+++ b/test/env.d.ts
@@ -1,0 +1,13 @@
+import type { D1Migration } from '@cloudflare/vitest-pool-workers';
+import type { Env as WorkerEnv } from '../worker/types.js';
+
+declare global {
+  namespace Cloudflare {
+    interface Env extends WorkerEnv {
+      /** Migrations read in Node by vitest.config.ts and applied in test/setup.ts. */
+      TEST_MIGRATIONS: D1Migration[];
+    }
+  }
+}
+
+export {};

--- a/test/errorHandling.test.ts
+++ b/test/errorHandling.test.ts
@@ -1,0 +1,208 @@
+import { env } from 'cloudflare:test';
+import type { Update } from 'grammy/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// The bundled build, not the TypeScript source — see test/globalSetup.ts.
+import { worker } from './generated/bot.mjs';
+import { WEBHOOK_PATH } from '../worker/webhookPath.js';
+import { getActiveEntriesForUser } from '../worker/db/entries.js';
+
+const BASE = 'https://iou-app.example.workers.dev';
+const SECRET = 'correct-webhook-secret';
+const ALICE = { id: 100, username: 'alice', chat: 500 };
+
+interface ApiCall {
+  method: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Drives updates through the Worker's real fetch handler, so the entry point's
+ * error handling is exercised rather than bypassed. Telegram is stubbed at
+ * `fetch`, which lets a chosen method be made to fail mid-flow.
+ */
+class WebhookHarness {
+  readonly calls: ApiCall[] = [];
+  readonly failing = new Set<string>();
+  private updateId = 0;
+  private messageId = 0;
+
+  install(): void {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = input instanceof Request ? await input.text() : String(init?.body ?? '{}');
+      const method = url.slice(url.lastIndexOf('/') + 1);
+      this.calls.push({ method, payload: JSON.parse(body) as Record<string, unknown> });
+
+      if (this.failing.has(method)) {
+        return Response.json({
+          ok: false,
+          error_code: 500,
+          description: 'Internal Server Error: telegram is having a moment',
+        });
+      }
+      return Response.json({ ok: true, result: this.resultFor(method) });
+    }) as typeof fetch;
+  }
+
+  private resultFor(method: string): unknown {
+    if (method === 'getMe') {
+      return { id: 42, is_bot: true, first_name: 'IOU', username: 'iou_test_bot' };
+    }
+    if (method === 'sendMessage' || method === 'editMessageText') {
+      return { message_id: ++this.messageId, date: 1_700_000_000, chat: { id: ALICE.chat } };
+    }
+    return true;
+  }
+
+  drain(): ApiCall[] {
+    return this.calls.splice(0, this.calls.length);
+  }
+
+  private post(update: Update): Promise<Response> {
+    return worker.fetch(
+      new Request(`${BASE}${WEBHOOK_PATH}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'X-Telegram-Bot-Api-Secret-Token': SECRET,
+        },
+        body: JSON.stringify(update),
+      }),
+      env,
+    );
+  }
+
+  command(text: string): Promise<Response> {
+    return this.post({
+      update_id: ++this.updateId,
+      message: {
+        message_id: ++this.messageId,
+        date: 1_700_000_000,
+        chat: { id: ALICE.chat, type: 'private', first_name: 'Test' },
+        from: { id: ALICE.id, is_bot: false, first_name: 'Test', username: ALICE.username },
+        text,
+        entities: [{ type: 'bot_command', offset: 0, length: text.length }],
+      },
+    } as Update);
+  }
+
+  text(text: string): Promise<Response> {
+    return this.post({
+      update_id: ++this.updateId,
+      message: {
+        message_id: ++this.messageId,
+        date: 1_700_000_000,
+        chat: { id: ALICE.chat, type: 'private', first_name: 'Test' },
+        from: { id: ALICE.id, is_bot: false, first_name: 'Test', username: ALICE.username },
+        text,
+      },
+    } as Update);
+  }
+
+  tap(data: string): Promise<Response> {
+    return this.post({
+      update_id: ++this.updateId,
+      callback_query: {
+        id: `cb${this.updateId}`,
+        chat_instance: 'ci',
+        data,
+        from: { id: ALICE.id, is_bot: false, first_name: 'Test', username: ALICE.username },
+        message: {
+          message_id: this.messageId,
+          date: 1_700_000_000,
+          chat: { id: ALICE.chat, type: 'private', first_name: 'Test' },
+        },
+      },
+    } as Update);
+  }
+}
+
+function textsOf(calls: ApiCall[]): string[] {
+  return calls
+    .filter((call) => call.method === 'sendMessage' || call.method === 'editMessageText')
+    .map((call) => String(call.payload.text));
+}
+
+let harness: WebhookHarness;
+
+beforeEach(async () => {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM entries'),
+    env.DB.prepare('DELETE FROM sessions'),
+    env.DB.prepare('DELETE FROM users'),
+  ]);
+  await env.DB.batch([
+    env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('alice', String(ALICE.chat), ALICE.id),
+    env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('bob', '600', 600),
+  ]);
+  harness = new WebhookHarness();
+  harness.install();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('a Telegram API failure mid-flow', () => {
+  it('tells the user instead of leaving them at a dead prompt', async () => {
+    await harness.command('/send');
+    harness.drain();
+
+    harness.failing.add('editMessageText');
+    const response = await harness.tap('SEND_RECIPIENT_bob');
+
+    // Still a 200, or Telegram retries the update and replays it.
+    expect(response.status).toBe(200);
+    expect(textsOf(harness.drain())).toContain(
+      '❌ Something went wrong. If you were in the middle of a guided flow it ' +
+        'has been cancelled — please start it again.',
+    );
+  });
+
+  it('logs which user and which action failed', async () => {
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await harness.command('/send');
+    harness.failing.add('editMessageText');
+    await harness.tap('SEND_RECIPIENT_bob');
+
+    const report = logged.mock.calls
+      .map(([entry]) => entry as Record<string, unknown>)
+      .find((entry) => entry?.message === 'update handling failed');
+
+    expect(report).toBeDefined();
+    expect(report?.username).toBe('alice');
+    expect(report?.action).toBe('callback:SEND_RECIPIENT_bob');
+    expect(String(report?.error)).toContain('Internal Server Error');
+  });
+
+  it('writes no entry and does not resume the broken flow', async () => {
+    await harness.command('/send');
+    harness.failing.add('editMessageText');
+    await harness.tap('SEND_RECIPIENT_bob');
+    harness.failing.clear();
+    harness.drain();
+
+    // If the flow were still alive this would be taken as the amount.
+    await harness.text('20');
+    await harness.text('rent');
+
+    expect(await getActiveEntriesForUser(env.DB, 'alice')).toHaveLength(0);
+  });
+
+  it('still answers 200 when even the apology cannot be delivered', async () => {
+    await harness.command('/send');
+    harness.failing.add('editMessageText');
+    harness.failing.add('sendMessage');
+
+    const response = await harness.tap('SEND_RECIPIENT_bob');
+    expect(response.status).toBe(200);
+  });
+
+  it('acknowledges a failure outside any conversation', async () => {
+    harness.failing.add('sendMessage');
+    const response = await harness.command('/hello');
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/test/flows.test.ts
+++ b/test/flows.test.ts
@@ -1,0 +1,364 @@
+import { env } from 'cloudflare:test';
+import type { Bot } from 'grammy';
+import type { Update, UserFromGetMe } from 'grammy/types';
+import { beforeEach, describe, expect, it } from 'vitest';
+// The bundled build, not the TypeScript source — see test/globalSetup.ts.
+import { createBot } from './generated/bot.mjs';
+import { getActiveEntriesBetween, getActiveEntriesForUser } from '../worker/db/entries.js';
+import type { BotContext } from '../worker/types.js';
+
+const BOT_INFO = {
+  id: 42,
+  is_bot: true,
+  first_name: 'IOU',
+  username: 'iou_test_bot',
+  can_join_groups: true,
+  can_read_all_group_messages: false,
+  supports_inline_queries: false,
+} as UserFromGetMe;
+
+const ALICE = { id: 100, username: 'alice', chat: 500 };
+const BOB = { id: 600, username: 'bob', chat: 600 };
+
+interface ApiCall {
+  method: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Drives real updates through the real bot, capturing outgoing Bot API calls.
+ * Conversation state goes through the D1 `sessions` table, so this also covers
+ * the storage adapter and the plugin's replay behaviour across updates.
+ */
+class BotHarness {
+  readonly calls: ApiCall[] = [];
+  private updateId = 0;
+  private messageId = 0;
+
+  constructor(private readonly bot: Bot<BotContext>) {}
+
+  static async create(): Promise<BotHarness> {
+    const harness = new BotHarness(await createBot(env, BOT_INFO));
+    // The conversations plugin builds its own Api instances per replay, so a
+    // grammY transformer would not see their calls. Stubbing fetch catches
+    // every Telegram request no matter which Api instance issues it.
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const body = input instanceof Request ? await input.text() : String(init?.body ?? '{}');
+      const method = url.slice(url.lastIndexOf('/') + 1);
+      harness.calls.push({ method, payload: JSON.parse(body) as Record<string, unknown> });
+      return Response.json({ ok: true, result: harness.resultFor(method) });
+    }) as typeof fetch;
+    return harness;
+  }
+
+  private resultFor(method: string): unknown {
+    if (method === 'sendMessage' || method === 'editMessageText') {
+      return { message_id: ++this.messageId, date: 1_700_000_000, chat: { id: ALICE.chat } };
+    }
+    return true;
+  }
+
+  /** Everything sent since the last call, so assertions stay scoped to a step. */
+  drain(): ApiCall[] {
+    return this.calls.splice(0, this.calls.length);
+  }
+
+  async command(user: typeof ALICE, text: string): Promise<void> {
+    await this.send(user, text, [{ type: 'bot_command', offset: 0, length: text.length }]);
+  }
+
+  async text(user: typeof ALICE, text: string): Promise<void> {
+    await this.send(user, text, undefined);
+  }
+
+  private async send(
+    user: typeof ALICE,
+    text: string,
+    entities: { type: string; offset: number; length: number }[] | undefined,
+  ): Promise<void> {
+    await this.bot.handleUpdate({
+      update_id: ++this.updateId,
+      message: {
+        message_id: ++this.messageId,
+        date: 1_700_000_000,
+        chat: { id: user.chat, type: 'private', first_name: 'Test' },
+        from: { id: user.id, is_bot: false, first_name: 'Test', username: user.username },
+        text,
+        entities,
+      },
+    } as Update);
+  }
+
+  async tap(user: typeof ALICE, data: string): Promise<void> {
+    await this.bot.handleUpdate({
+      update_id: ++this.updateId,
+      callback_query: {
+        id: `cb${this.updateId}`,
+        chat_instance: 'ci',
+        data,
+        from: { id: user.id, is_bot: false, first_name: 'Test', username: user.username },
+        message: {
+          message_id: this.messageId,
+          date: 1_700_000_000,
+          chat: { id: user.chat, type: 'private', first_name: 'Test' },
+        },
+      },
+    } as Update);
+  }
+}
+
+function textsOf(calls: ApiCall[]): string[] {
+  return calls
+    .filter((call) => call.method === 'sendMessage' || call.method === 'editMessageText')
+    .map((call) => String(call.payload.text));
+}
+
+beforeEach(async () => {
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM entries'),
+    env.DB.prepare('DELETE FROM sessions'),
+    env.DB.prepare('DELETE FROM users'),
+  ]);
+  await env.DB.batch([
+    env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('alice', String(ALICE.chat), ALICE.id),
+    env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('bob', String(BOB.chat), BOB.id),
+  ]);
+});
+
+describe('/send', () => {
+  it('walks recipient, amount and description, then writes the entry', async () => {
+    const harness = await BotHarness.create();
+
+    await harness.command(ALICE, '/send');
+    const prompt = harness.drain();
+    expect(textsOf(prompt)).toEqual(['Select a recipient:']);
+    expect(JSON.stringify(prompt[0]?.payload.reply_markup)).toContain('SEND_RECIPIENT_bob');
+
+    await harness.tap(ALICE, 'SEND_RECIPIENT_bob');
+    expect(textsOf(harness.drain()).join()).toContain('Enter the amount you want to send');
+
+    await harness.text(ALICE, '$1,234.50');
+    expect(textsOf(harness.drain()).join()).toContain('Enter a description');
+
+    await harness.text(ALICE, 'rent');
+    const done = textsOf(harness.drain());
+
+    expect(done.some((text) => text === '✅ You sent @bob $1,234.50 for rent')).toBe(true);
+    expect(done.some((text) => text === '@alice sent you $1,234.50 for rent')).toBe(true);
+
+    const entries = await getActiveEntriesBetween(env.DB, 'alice', 'bob');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      sender: 'alice',
+      recipient: 'bob',
+      amount: 1234.5,
+      description: 'rent',
+      deleted: 0,
+    });
+  });
+
+  it('reprompts on an unparseable amount instead of dropping the flow', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/send');
+    await harness.tap(ALICE, 'SEND_RECIPIENT_bob');
+    harness.drain();
+
+    await harness.text(ALICE, '12.34.56');
+    expect(textsOf(harness.drain()).join()).toContain('Unable to parse amount');
+
+    await harness.text(ALICE, 'twenty');
+    expect(textsOf(harness.drain()).join()).toContain('contains invalid characters');
+
+    await harness.text(ALICE, '20');
+    await harness.text(ALICE, 'lunch');
+
+    const entries = await getActiveEntriesBetween(env.DB, 'alice', 'bob');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.amount).toBe(20);
+  });
+
+  it('abandons the flow on /cancel and writes nothing', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/send');
+    await harness.tap(ALICE, 'SEND_RECIPIENT_bob');
+    harness.drain();
+
+    await harness.text(ALICE, '/cancel');
+    expect(textsOf(harness.drain())).toContain('Cancelled.');
+
+    expect(await getActiveEntriesForUser(env.DB, 'alice')).toHaveLength(0);
+    // The conversation is over, so a stray message is no longer captured.
+    await harness.text(ALICE, '20');
+    expect(harness.drain()).toEqual([]);
+  });
+});
+
+describe('/bill', () => {
+  it('records the other user as the one who owes', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/bill');
+    await harness.tap(ALICE, 'BILL_SENDER_bob');
+    await harness.text(ALICE, '15');
+    await harness.text(ALICE, 'tickets');
+
+    const entries = await getActiveEntriesBetween(env.DB, 'alice', 'bob');
+    expect(entries[0]).toMatchObject({ sender: 'bob', recipient: 'alice', amount: 15 });
+  });
+});
+
+describe('/settle', () => {
+  it('shows the balance, waits for confirmation, then soft-deletes everything', async () => {
+    const harness = await BotHarness.create();
+
+    await harness.command(ALICE, '/send');
+    await harness.tap(ALICE, 'SEND_RECIPIENT_bob');
+    await harness.text(ALICE, '30');
+    await harness.text(ALICE, 'dinner');
+    harness.drain();
+
+    await harness.command(ALICE, '/settle');
+    await harness.tap(ALICE, 'SETTLE_USER_bob');
+    const summary = textsOf(harness.drain()).join();
+    expect(summary).toContain('@alice owes @bob $30.00');
+    expect(summary).toContain('This will erase all transaction history between you.');
+
+    await harness.tap(ALICE, 'SETTLE_CONFIRM_YES');
+    const result = textsOf(harness.drain()).join();
+    expect(result).toContain('1 transaction(s) totaling $30.00 have been settled');
+
+    expect(await getActiveEntriesBetween(env.DB, 'alice', 'bob')).toHaveLength(0);
+    const row = await env.DB.prepare('SELECT deleted FROM entries').first<{ deleted: number }>();
+    expect(row?.deleted).toBe(1);
+  });
+
+  it('keeps the entries when the user declines', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/bill');
+    await harness.tap(ALICE, 'BILL_SENDER_bob');
+    await harness.text(ALICE, '10');
+    await harness.text(ALICE, 'x');
+
+    await harness.command(ALICE, '/settle');
+    await harness.tap(ALICE, 'SETTLE_USER_bob');
+    harness.drain();
+    await harness.tap(ALICE, 'SETTLE_CONFIRM_NO');
+
+    expect(textsOf(harness.drain())).toContain('Settlement cancelled.');
+    expect(await getActiveEntriesBetween(env.DB, 'alice', 'bob')).toHaveLength(1);
+  });
+
+  it('refuses to settle when nothing is outstanding', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/settle');
+    await harness.tap(ALICE, 'SETTLE_USER_bob');
+
+    expect(textsOf(harness.drain()).join()).toContain(
+      'No outstanding transactions between you and @bob to settle.',
+    );
+  });
+});
+
+describe('/split', () => {
+  it('charges each non-payer participant an even share', async () => {
+    await env.DB.prepare('INSERT INTO users VALUES (?, ?, ?)').bind('carol', '700', 700).run();
+    const harness = await BotHarness.create();
+
+    await harness.command(ALICE, '/split');
+    await harness.tap(ALICE, 'SPLIT_PAYER_alice');
+    await harness.text(ALICE, '60');
+    await harness.text(ALICE, 'dinner');
+    harness.drain();
+
+    // Only the initiator and the payer start selected — here both are alice.
+    await harness.tap(ALICE, 'SPLIT_PART_TOGGLE_bob');
+    await harness.tap(ALICE, 'SPLIT_PART_TOGGLE_carol');
+    await harness.tap(ALICE, 'SPLIT_PART_DONE');
+    expect(textsOf(harness.drain())).toContain('✅ Split successful!');
+
+    const entries = await getActiveEntriesForUser(env.DB, 'alice');
+    expect(entries).toHaveLength(2);
+    expect(entries.every((entry) => entry.recipient === 'alice')).toBe(true);
+    expect(entries.every((entry) => entry.amount === 20)).toBe(true);
+    expect(entries[0]?.description).toBe(
+      'Split: dinner | Total: $60.00 | Participants: alice, bob, carol',
+    );
+  });
+
+  it('will not let the payer be removed from the split', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/split');
+    await harness.tap(ALICE, 'SPLIT_PAYER_bob');
+    await harness.text(ALICE, '10');
+    await harness.text(ALICE, 'x');
+    harness.drain();
+
+    await harness.tap(ALICE, 'SPLIT_PART_TOGGLE_bob');
+    expect(textsOf(harness.drain()).join()).toContain(
+      'The payer @bob cannot be removed from the split.',
+    );
+  });
+});
+
+describe('/query and /list', () => {
+  it('reports the net balance between two users', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/send');
+    await harness.tap(ALICE, 'SEND_RECIPIENT_bob');
+    await harness.text(ALICE, '25');
+    await harness.text(ALICE, 'x');
+    harness.drain();
+
+    await harness.command(ALICE, '/query');
+    await harness.tap(ALICE, 'QUERY_USER1_alice');
+    await harness.tap(ALICE, 'QUERY_USER2_bob');
+
+    expect(textsOf(harness.drain())).toContain('@alice owes @bob $25.00');
+  });
+
+  it('lists the caller’s transactions', async () => {
+    const harness = await BotHarness.create();
+    await harness.command(ALICE, '/list');
+    expect(textsOf(harness.drain())).toContain('You have no transactions.');
+
+    await harness.command(ALICE, '/bill');
+    await harness.tap(ALICE, 'BILL_SENDER_bob');
+    await harness.text(ALICE, '12.34');
+    await harness.text(ALICE, 'coffee');
+    harness.drain();
+
+    await harness.command(ALICE, '/list');
+    const listing = textsOf(harness.drain()).join();
+    expect(listing).toContain('📋 Your Transaction History:');
+    expect(listing).toContain('➕ @bob owes you $12.34');
+    expect(listing).toContain('📝 coffee');
+  });
+});
+
+describe('simple commands', () => {
+  it('answers /hello, /help and /version', async () => {
+    const harness = await BotHarness.create();
+
+    await harness.command(ALICE, '/hello');
+    expect(textsOf(harness.drain())).toContain('Hello to yourself!');
+
+    await harness.command(ALICE, '/help');
+    expect(textsOf(harness.drain()).join()).toContain('To send money: /send');
+
+    await harness.command(ALICE, '/version');
+    expect(textsOf(harness.drain())).toContain('App version: 1.0.0');
+  });
+
+  it('registers an allowlisted user who has never started the bot', async () => {
+    await env.DB.prepare('UPDATE users SET conversation_id = NULL WHERE username = ?')
+      .bind('alice')
+      .run();
+    const harness = await BotHarness.create();
+
+    await harness.command(ALICE, '/start');
+    expect(textsOf(harness.drain())).toContain('Registration successful!');
+
+    await harness.command(ALICE, '/start');
+    expect(textsOf(harness.drain())).toContain('You are already registered.');
+  });
+});

--- a/test/generated/bot.d.mts
+++ b/test/generated/bot.d.mts
@@ -1,0 +1,4 @@
+// Types for the esbuild bundle that test/globalSetup.ts writes next to this
+// file. The bundle is gitignored; this declaration keeps `tsc --noEmit` working
+// whether or not it has been built yet.
+export { createBot } from '../../worker/bot/index.js';

--- a/test/generated/bot.d.mts
+++ b/test/generated/bot.d.mts
@@ -2,3 +2,4 @@
 // file. The bundle is gitignored; this declaration keeps `tsc --noEmit` working
 // whether or not it has been built yet.
 export { createBot } from '../../worker/bot/index.js';
+export { default as worker } from '../../worker/index.js';

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,0 +1,22 @@
+import { build } from 'esbuild';
+
+/**
+ * `@grammyjs/conversations` ships CommonJS that `require`s grammY, whose
+ * Workers entry point is ESM. Wrangler's esbuild pass reconciles the two;
+ * Vite's module runner does not, and every conversation throws on the
+ * unresolved re-export. So the flow tests import a bundle produced the same
+ * way the deployed Worker is, which also proves the real bundle works.
+ */
+export async function setup(): Promise<void> {
+  await build({
+    entryPoints: ['test/botEntry.ts'],
+    outfile: 'test/generated/bot.mjs',
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2022',
+    conditions: ['workerd', 'worker', 'browser'],
+    external: ['cloudflare:*', 'node:*'],
+    logLevel: 'warning',
+  });
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,3 @@
+import { applyD1Migrations, env } from 'cloudflare:test';
+
+await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);

--- a/test/split.test.ts
+++ b/test/split.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { SplitError, computeSplit } from '../worker/domain/split.js';
+
+describe('computeSplit', () => {
+  it('counts the payer in the divisor but gives them no entry', () => {
+    const result = computeSplit({
+      payer: 'alice',
+      amount: 60,
+      participants: ['alice', 'bob', 'carol'],
+      description: 'dinner',
+    });
+
+    expect(result.evenShare).toBe(20);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries.map((e) => e.sender)).toEqual(['bob', 'carol']);
+    expect(result.entries.every((e) => e.recipient === 'alice')).toBe(true);
+    expect(result.entries.every((e) => e.amount === 20)).toBe(true);
+  });
+
+  it('has every participant owe the payer, so the payer is owed share × (n-1)', () => {
+    const result = computeSplit({
+      payer: 'alice',
+      amount: 100,
+      participants: ['alice', 'bob', 'carol', 'dave'],
+      description: 'tickets',
+    });
+    const owedToPayer = result.entries.reduce((sum, e) => sum + e.amount, 0);
+    expect(result.evenShare).toBe(25);
+    expect(owedToPayer).toBe(75);
+  });
+
+  it('rounds the share to 2dp, matching the legacy backend', () => {
+    const result = computeSplit({
+      payer: 'alice',
+      amount: 10,
+      participants: ['alice', 'bob', 'carol'],
+      description: 'coffee',
+    });
+    expect(result.evenShare).toBe(3.33);
+  });
+
+  it('embeds the total and participants in each entry description', () => {
+    const result = computeSplit({
+      payer: 'alice',
+      amount: 1234.5,
+      participants: ['alice', 'bob'],
+      description: 'hotel',
+    });
+    expect(result.entries[0]?.description).toBe(
+      'Split: hotel | Total: $1234.50 | Participants: alice, bob',
+    );
+  });
+
+  it('still divides by the participant count when the payer is not a participant', () => {
+    const result = computeSplit({
+      payer: 'alice',
+      amount: 30,
+      participants: ['bob', 'carol'],
+      description: 'gift',
+    });
+    expect(result.evenShare).toBe(15);
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it('refuses a split with fewer than two participants', () => {
+    expect(() =>
+      computeSplit({ payer: 'alice', amount: 10, participants: ['alice'], description: 'x' }),
+    ).toThrow(SplitError);
+    expect(() =>
+      computeSplit({ payer: 'alice', amount: 10, participants: ['alice'], description: 'x' }),
+    ).toThrow('At least two participants are required for a split.');
+  });
+});

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,0 +1,70 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import worker from '../worker/index.js';
+import { WEBHOOK_PATH } from '../worker/webhookPath.js';
+import { VERSION } from '../worker/version.js';
+
+const BASE = 'https://iou-app.example.workers.dev';
+
+function post(path: string, secret?: string): Request {
+  const headers = new Headers({ 'content-type': 'application/json' });
+  if (secret !== undefined) headers.set('X-Telegram-Bot-Api-Secret-Token', secret);
+  return new Request(`${BASE}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ update_id: 1 }),
+  });
+}
+
+const call = (request: Request): Promise<Response> => worker.fetch(request, env);
+
+describe('webhook route', () => {
+  it('rejects an update with no secret token', async () => {
+    const response = await call(post(WEBHOOK_PATH));
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects an update with the wrong secret token', async () => {
+    const response = await call(post(WEBHOOK_PATH, 'not-the-secret'));
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a token that is a prefix of the real one', async () => {
+    const response = await call(post(WEBHOOK_PATH, 'correct-webhook-secre'));
+    expect(response.status).toBe(401);
+  });
+
+  it('does not answer on the path without the random segment', async () => {
+    const response = await call(post('/telegram', 'correct-webhook-secret'));
+    expect(response.status).toBe(404);
+  });
+
+  it('does not answer on a guessed path segment', async () => {
+    const response = await call(post('/telegram/00000000000000000000000000000000'));
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects a GET on the webhook path', async () => {
+    const request = new Request(`${BASE}${WEBHOOK_PATH}`, { method: 'GET' });
+    expect((await call(request)).status).toBe(405);
+  });
+
+  it('exposes nothing else', async () => {
+    for (const path of ['/', '/entries', '/users', '/version']) {
+      const request = new Request(`${BASE}${path}`);
+      expect((await call(request)).status).toBe(404);
+    }
+  });
+});
+
+describe('healthcheck', () => {
+  it('reports ok and the build version without auth', async () => {
+    const response = await call(new Request(`${BASE}/healthcheck`));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok', version: VERSION });
+  });
+
+  it('reports version 1.0.0', () => {
+    expect(VERSION).toBe('1.0.0');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"],
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["worker/**/*.ts", "test/**/*.ts", "test/generated/*.d.mts", "vitest.config.ts", "package.json"],
+  "exclude": ["node_modules", "dist", ".venv"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import { cloudflareTest, readD1Migrations } from '@cloudflare/vitest-pool-workers';
+
+// Read in Node so the tests, which run inside workerd, can apply the real
+// migration files rather than a hand-copied schema that could drift.
+const migrations = await readD1Migrations('./migrations');
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      miniflare: {
+        compatibilityDate: '2026-08-08',
+        compatibilityFlags: ['nodejs_compat'],
+        d1Databases: ['DB'],
+        bindings: {
+          TELEGRAM_BOT_TOKEN: '123456:test-token',
+          TELEGRAM_WEBHOOK_SECRET: 'correct-webhook-secret',
+          TEST_MIGRATIONS: migrations,
+        },
+      },
+    }),
+  ],
+  test: {
+    globalSetup: ['./test/globalSetup.ts'],
+    setupFiles: ['./test/setup.ts'],
+  },
+});

--- a/worker/bot/auth.ts
+++ b/worker/bot/auth.ts
@@ -1,0 +1,56 @@
+import type { MiddlewareFn } from 'grammy';
+import { backfillTelegramUserId, getUserByTelegramId, getUserByUsername } from '../db/users.js';
+import type { BotContext, Env } from '../types.js';
+import { GENERIC_ERROR, NO_USERNAME, UNAUTHORIZED, UNAUTHORIZED_CALLBACK } from './strings.js';
+
+async function refuse(ctx: BotContext, text: string, callbackText: string): Promise<void> {
+  if (ctx.callbackQuery !== undefined) {
+    await ctx.answerCallbackQuery({ text: callbackText, show_alert: true });
+    return;
+  }
+  if (ctx.chat !== undefined) {
+    await ctx.reply(text);
+  }
+}
+
+/**
+ * Gates every update on the `users` allowlist. There is no self-signup: rows
+ * are added to D1 by hand. Fails closed — a database error refuses the update
+ * rather than letting it through.
+ */
+export function authorize(env: Env): MiddlewareFn<BotContext> {
+  return async (ctx, next) => {
+    const from = ctx.from;
+    if (from === undefined) return;
+    if (from.is_bot) return;
+
+    let user = null;
+    try {
+      // The numeric id is stable across username changes, so prefer it.
+      user = await getUserByTelegramId(env.DB, from.id);
+      if (user === null && from.username !== undefined) {
+        const byName = await getUserByUsername(env.DB, from.username);
+        if (byName !== null && byName.telegram_user_id === null) {
+          // First sighting of an allowlisted account: bind the numeric id so a
+          // later username change cannot lock them out, and so nobody who
+          // renames themselves into this username can take it over.
+          await backfillTelegramUserId(env.DB, byName.username, from.id);
+          user = { ...byName, telegram_user_id: from.id };
+        }
+      }
+    } catch (error) {
+      console.error({ message: 'authorization lookup failed', error: String(error) });
+      await refuse(ctx, GENERIC_ERROR, GENERIC_ERROR);
+      return;
+    }
+
+    if (user === null) {
+      const text = from.username === undefined ? NO_USERNAME : UNAUTHORIZED;
+      await refuse(ctx, text, UNAUTHORIZED_CALLBACK);
+      return;
+    }
+
+    ctx.iouUser = user;
+    await next();
+  };
+}

--- a/worker/bot/helpers.ts
+++ b/worker/bot/helpers.ts
@@ -1,0 +1,142 @@
+import { InlineKeyboard } from 'grammy';
+import type { Api } from 'grammy';
+import { AmountError, validateAmountStr } from '../domain/amount.js';
+import { chunkButtons } from '../domain/format.js';
+import { getUserByUsername, isRegistered, listUsers } from '../db/users.js';
+import type { ConversationContext, IouConversation } from '../types.js';
+import { CANCELLED } from './strings.js';
+
+export function usernameKeyboard(
+  usernames: readonly string[],
+  prefix: string,
+  perRow: number,
+): InlineKeyboard {
+  return InlineKeyboard.from(
+    chunkButtons(usernames, perRow).map((row) =>
+      row.map((username) => InlineKeyboard.text(username, `${prefix}${username}`)),
+    ),
+  );
+}
+
+/** All authorized usernames, optionally minus the caller (legacy get_chat_members). */
+export async function listUsernames(db: D1Database, exclude?: string | null): Promise<string[]> {
+  const users = await listUsers(db);
+  return users.map((user) => user.username).filter((username) => username !== exclude);
+}
+
+/** The chat a user can be notified in, or null if they have never run /start. */
+export async function conversationIdFor(
+  db: D1Database,
+  username: string,
+): Promise<string | null> {
+  const user = await getUserByUsername(db, username);
+  return isRegistered(user) ? user.conversation_id : null;
+}
+
+export async function conversationIdsFor(
+  db: D1Database,
+  usernames: readonly string[],
+): Promise<Record<string, string | null>> {
+  const users = await listUsers(db);
+  const byName = new Map(users.map((user) => [user.username, user]));
+  const result: Record<string, string | null> = {};
+  for (const username of usernames) {
+    const user = byName.get(username) ?? null;
+    result[username] = isRegistered(user) ? user.conversation_id : null;
+  }
+  return result;
+}
+
+/**
+ * Notifies a user in their own chat. Runs through the conversation-aware `api`
+ * so replays do not resend it, and a delivery failure (blocked bot, stale chat
+ * id) never breaks the sender's flow.
+ */
+export async function trySend(api: Api, chatId: string, text: string): Promise<void> {
+  try {
+    await api.sendMessage(Number(chatId), text);
+  } catch (error) {
+    console.error({ message: 'notification failed', chatId, error: String(error) });
+  }
+}
+
+interface CallbackSelection {
+  ctx: ConversationContext;
+  value: string;
+}
+
+function isCancel(ctx: ConversationContext): boolean {
+  return ctx.message?.text?.trim() === '/cancel';
+}
+
+/**
+ * Waits for a callback query whose data starts with `prefix`, ignoring anything
+ * else, and treats /cancel as an abort. `conversation.halt()` never returns.
+ */
+export async function waitForSelection(
+  conversation: IouConversation,
+  prefix: string,
+): Promise<CallbackSelection> {
+  for (;;) {
+    const ctx = await conversation.wait();
+    if (isCancel(ctx)) {
+      await ctx.reply(CANCELLED);
+      await conversation.halt();
+    }
+    const data = ctx.callbackQuery?.data;
+    if (data === undefined) continue;
+    await ctx.answerCallbackQuery();
+    if (data.startsWith(prefix)) {
+      return { ctx, value: data.slice(prefix.length) };
+    }
+  }
+}
+
+/** Waits for a plain text message, treating /cancel as an abort. */
+export async function waitForText(
+  conversation: IouConversation,
+): Promise<{ ctx: ConversationContext; text: string }> {
+  for (;;) {
+    const ctx = await conversation.wait();
+    if (isCancel(ctx)) {
+      await ctx.reply(CANCELLED);
+      await conversation.halt();
+    }
+    if (ctx.callbackQuery !== undefined) {
+      await ctx.answerCallbackQuery();
+      continue;
+    }
+    const text = ctx.message?.text?.trim();
+    if (text === undefined || text === '') continue;
+    if (text.startsWith('/')) {
+      await ctx.reply('Please answer the question above, or /cancel to start over.');
+      continue;
+    }
+    return { ctx, text };
+  }
+}
+
+/**
+ * Asks until a parseable, positive amount arrives. The legacy bot only
+ * validated after the description step and then dropped the whole flow; this
+ * reprompts instead.
+ */
+export async function askAmount(
+  conversation: IouConversation,
+): Promise<{ ctx: ConversationContext; raw: string; value: number }> {
+  for (;;) {
+    const { ctx, text } = await waitForText(conversation);
+    try {
+      return { ctx, raw: text, value: validateAmountStr(text) };
+    } catch (error) {
+      const message = error instanceof AmountError ? error.message : 'Invalid amount.';
+      await ctx.reply(`❌ Error: ${message}\n\nEnter the amount again, or /cancel.`);
+    }
+  }
+}
+
+/** Renders a user-facing error line, matching the legacy "❌ Error: …" phrasing. */
+export function errorText(error: unknown, retryCommand: string): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `❌ Error: ${message}\n\nTap here to try again: ${retryCommand}`;
+}

--- a/worker/bot/index.ts
+++ b/worker/bot/index.ts
@@ -135,9 +135,8 @@ export async function createBot(
     await ctx.reply(`App version: ${VERSION}`);
   });
 
-  bot.catch((error) => {
-    console.error({ message: 'unhandled bot error', error: String(error.error) });
-  });
-
+  // No `bot.catch` here: grammY only consults that handler from the polling
+  // loop, so under `webhookCallback` it would be dead code. Middleware errors
+  // are handled where they actually surface, in worker/index.ts.
   return bot;
 }

--- a/worker/bot/index.ts
+++ b/worker/bot/index.ts
@@ -1,0 +1,143 @@
+import { Bot } from 'grammy';
+import type { UserFromGetMe } from 'grammy/types';
+import { conversations, createConversation } from '@grammyjs/conversations';
+import { createD1Storage } from '../db/sessionStore.js';
+import { getActiveEntriesForUser } from '../db/entries.js';
+import { setConversationId } from '../db/users.js';
+import { chunkText, formatTransactions } from '../domain/format.js';
+import { VERSION } from '../version.js';
+import type { BotContext, ConversationContext, Env } from '../types.js';
+import { authorize } from './auth.js';
+import { BILL_CONVERSATION, billFlow } from '../flows/bill.js';
+import { QUERY_CONVERSATION, queryFlow } from '../flows/query.js';
+import { SEND_CONVERSATION, sendFlow } from '../flows/send.js';
+import { SETTLE_CONVERSATION, settleFlow } from '../flows/settle.js';
+import { SPLIT_CONVERSATION, splitFlow } from '../flows/split.js';
+import {
+  ALREADY_REGISTERED,
+  GENERIC_ERROR,
+  HELLO,
+  HELP,
+  NOTHING_TO_CANCEL,
+  REGISTRATION_SUCCESSFUL,
+} from './strings.js';
+
+/** A guided flow left half-finished expires rather than trapping the user forever. */
+const CONVERSATION_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * `getMe` is the same for the life of the deployment, so cache it across
+ * requests on the same isolate instead of paying a Telegram round trip per
+ * update. This is deployment-wide data, never request state.
+ */
+let cachedBotInfo: UserFromGetMe | undefined;
+
+export async function createBot(
+  env: Env,
+  botInfo: UserFromGetMe | undefined = cachedBotInfo,
+): Promise<Bot<BotContext>> {
+  const bot = new Bot<BotContext>(env.TELEGRAM_BOT_TOKEN, { botInfo });
+  if (botInfo === undefined) {
+    await bot.init();
+    cachedBotInfo = bot.botInfo;
+  }
+
+  bot.use(authorize(env));
+
+  bot.use(
+    conversations<BotContext, ConversationContext>({
+      storage: {
+        type: 'key',
+        version: 1,
+        adapter: createD1Storage(env.DB),
+        // Per chat *and* per user, matching python-telegram-bot's default so
+        // two people in a group chat cannot walk into each other's flow.
+        getStorageKey: (ctx) =>
+          ctx.chat === undefined || ctx.from === undefined
+            ? undefined
+            : `${ctx.chat.id}:${ctx.from.id}`,
+      },
+    }),
+  );
+
+  const flows = [
+    [SEND_CONVERSATION, sendFlow(env)],
+    [BILL_CONVERSATION, billFlow(env)],
+    [QUERY_CONVERSATION, queryFlow(env)],
+    [SPLIT_CONVERSATION, splitFlow(env)],
+    [SETTLE_CONVERSATION, settleFlow(env)],
+  ] as const;
+
+  for (const [id, builder] of flows) {
+    bot.use(
+      createConversation(builder, {
+        id,
+        maxMillisecondsToWait: CONVERSATION_TIMEOUT_MS,
+      }),
+    );
+  }
+
+  bot.command('start', async (ctx) => {
+    const user = ctx.iouUser;
+    if (user.conversation_id !== null && user.conversation_id !== '') {
+      await ctx.reply(ALREADY_REGISTERED);
+      return;
+    }
+    if (ctx.chat === undefined) return;
+    try {
+      await setConversationId(env.DB, user.username, String(ctx.chat.id));
+    } catch (error) {
+      console.error({ message: 'registration failed', error: String(error) });
+      await ctx.reply(GENERIC_ERROR);
+      return;
+    }
+    await ctx.reply(REGISTRATION_SUCCESSFUL);
+  });
+
+  bot.command('send', async (ctx) => ctx.conversation.enter(SEND_CONVERSATION));
+  bot.command('bill', async (ctx) => ctx.conversation.enter(BILL_CONVERSATION));
+  bot.command('query', async (ctx) => ctx.conversation.enter(QUERY_CONVERSATION));
+  bot.command('split', async (ctx) => ctx.conversation.enter(SPLIT_CONVERSATION));
+  bot.command('settle', async (ctx) => ctx.conversation.enter(SETTLE_CONVERSATION));
+
+  bot.command('cancel', async (ctx) => {
+    await ctx.reply(NOTHING_TO_CANCEL);
+  });
+
+  bot.command('list', async (ctx) => {
+    const username = ctx.iouUser.username;
+    let entries;
+    try {
+      entries = await getActiveEntriesForUser(env.DB, username);
+    } catch (error) {
+      console.error({ message: 'list failed', error: String(error) });
+      await ctx.reply(GENERIC_ERROR);
+      return;
+    }
+    if (entries.length === 0) {
+      await ctx.reply('You have no transactions.');
+      return;
+    }
+    for (const chunk of chunkText(formatTransactions(entries, username))) {
+      await ctx.reply(chunk);
+    }
+  });
+
+  bot.command('hello', async (ctx) => {
+    await ctx.reply(HELLO);
+  });
+
+  bot.command('help', async (ctx) => {
+    await ctx.reply(HELP);
+  });
+
+  bot.command('version', async (ctx) => {
+    await ctx.reply(`App version: ${VERSION}`);
+  });
+
+  bot.catch((error) => {
+    console.error({ message: 'unhandled bot error', error: String(error.error) });
+  });
+
+  return bot;
+}

--- a/worker/bot/strings.ts
+++ b/worker/bot/strings.ts
@@ -1,0 +1,25 @@
+/** User-facing text, kept close to the legacy bot's phrasing (bot/main.py). */
+
+export const UNAUTHORIZED = 'Sorry, you are not authorized to use this bot.';
+export const UNAUTHORIZED_CALLBACK = 'Unauthorized access!';
+export const NO_USERNAME = 'You must have a Telegram username to use this bot.';
+export const ALREADY_REGISTERED = 'You are already registered.';
+export const REGISTRATION_SUCCESSFUL = 'Registration successful!';
+export const GENERIC_ERROR = 'An error occurred. Please try again later.';
+export const CANCELLED = 'Cancelled.';
+export const NOTHING_TO_CANCEL = 'There is nothing to cancel.';
+export const HELLO = 'Hello to yourself!';
+
+export const HELP = [
+  'To send money: /send (inline guided flow)',
+  'To bill someone: /bill (inline guided flow)',
+  'To check IOU status: /query (inline guided flow)',
+  'To split a bill among multiple participants: /split (inline guided flow)',
+  'To settle all transactions with another user: /settle (inline guided flow)',
+  'To list your transactions: /list',
+  'To abandon a guided flow: /cancel',
+].join('\n\n');
+
+export function notRegistered(username: string, role = 'User'): string {
+  return `${role} @${username} is not registered. They need to /start the bot first.`;
+}

--- a/worker/db/entries.ts
+++ b/worker/db/entries.ts
@@ -1,0 +1,108 @@
+export interface EntryRow {
+  id: string;
+  created_at: string;
+  conversation_id: string | null;
+  sender: string;
+  recipient: string;
+  amount: number;
+  description: string | null;
+  deleted: number;
+  deleted_at: string | null;
+}
+
+export interface NewEntry {
+  conversationId: string | null;
+  sender: string;
+  recipient: string;
+  amount: number;
+  description: string | null;
+}
+
+/** Legacy timestamp format, now written in UTC. */
+export function nowTimestamp(): string {
+  return new Date().toISOString().slice(0, 19).replace('T', ' ');
+}
+
+const INSERT_SQL = `INSERT INTO entries
+  (id, created_at, conversation_id, sender, recipient, amount, description, deleted, deleted_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL)`;
+
+function insertStatement(db: D1Database, entry: NewEntry, createdAt: string): D1PreparedStatement {
+  return db
+    .prepare(INSERT_SQL)
+    .bind(
+      crypto.randomUUID(),
+      createdAt,
+      entry.conversationId,
+      entry.sender,
+      entry.recipient,
+      entry.amount,
+      entry.description,
+    );
+}
+
+export async function addEntry(db: D1Database, entry: NewEntry): Promise<void> {
+  await insertStatement(db, entry, nowTimestamp()).run();
+}
+
+/** All entries of a split are written in one transaction so a split is all-or-nothing. */
+export async function addEntries(db: D1Database, entries: readonly NewEntry[]): Promise<void> {
+  if (entries.length === 0) return;
+  const createdAt = nowTimestamp();
+  await db.batch(entries.map((entry) => insertStatement(db, entry, createdAt)));
+}
+
+export async function getActiveEntriesBetween(
+  db: D1Database,
+  user1: string,
+  user2: string,
+): Promise<EntryRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM entries
+       WHERE deleted = 0
+         AND ((sender = ?1 AND recipient = ?2) OR (sender = ?2 AND recipient = ?1))
+       ORDER BY created_at`,
+    )
+    .bind(user1, user2)
+    .all<EntryRow>();
+  return results;
+}
+
+export async function getActiveEntriesForUser(
+  db: D1Database,
+  username: string,
+): Promise<EntryRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM entries
+       WHERE deleted = 0 AND (sender = ?1 OR recipient = ?1)
+       ORDER BY created_at`,
+    )
+    .bind(username)
+    .all<EntryRow>();
+  return results;
+}
+
+/**
+ * Soft-deletes every active entry between the two users.
+ *
+ * A single UPDATE, so unlike the legacy per-row loop (which could stop halfway
+ * and leave a partially settled balance) this either settles everything or
+ * nothing. Returns the number of entries settled.
+ */
+export async function settleBetween(
+  db: D1Database,
+  user1: string,
+  user2: string,
+): Promise<number> {
+  const result = await db
+    .prepare(
+      `UPDATE entries SET deleted = 1, deleted_at = ?3
+       WHERE deleted = 0
+         AND ((sender = ?1 AND recipient = ?2) OR (sender = ?2 AND recipient = ?1))`,
+    )
+    .bind(user1, user2, nowTimestamp())
+    .run();
+  return result.meta.changes ?? 0;
+}

--- a/worker/db/sessionStore.ts
+++ b/worker/db/sessionStore.ts
@@ -1,0 +1,33 @@
+import type { VersionedState, VersionedStateStorage } from '@grammyjs/conversations';
+
+/**
+ * Storage adapter for the conversations plugin, backed by the `sessions` table.
+ * Conversation state has to outlive the request on Workers, so it cannot use
+ * the plugin's default in-memory storage.
+ */
+export function createD1Storage<S>(db: D1Database): VersionedStateStorage<string, S> {
+  return {
+    async read(key: string): Promise<VersionedState<S> | undefined> {
+      const row = await db
+        .prepare('SELECT value FROM sessions WHERE key = ?')
+        .bind(key)
+        .first<{ value: string }>();
+      if (row === null) return undefined;
+      return JSON.parse(row.value) as VersionedState<S>;
+    },
+
+    async write(key: string, state: VersionedState<S>): Promise<void> {
+      await db
+        .prepare(
+          `INSERT INTO sessions (key, value) VALUES (?, ?)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+        )
+        .bind(key, JSON.stringify(state))
+        .run();
+    },
+
+    async delete(key: string): Promise<void> {
+      await db.prepare('DELETE FROM sessions WHERE key = ?').bind(key).run();
+    },
+  };
+}

--- a/worker/db/users.ts
+++ b/worker/db/users.ts
@@ -1,0 +1,75 @@
+export interface UserRow {
+  username: string;
+  conversation_id: string | null;
+  telegram_user_id: number | null;
+}
+
+export async function listUsers(db: D1Database): Promise<UserRow[]> {
+  const { results } = await db
+    .prepare('SELECT username, conversation_id, telegram_user_id FROM users ORDER BY username')
+    .all<UserRow>();
+  return results;
+}
+
+export async function getUserByUsername(
+  db: D1Database,
+  username: string,
+): Promise<UserRow | null> {
+  return db
+    .prepare(
+      'SELECT username, conversation_id, telegram_user_id FROM users WHERE username = ?',
+    )
+    .bind(username)
+    .first<UserRow>();
+}
+
+export async function getUserByTelegramId(
+  db: D1Database,
+  telegramUserId: number,
+): Promise<UserRow | null> {
+  return db
+    .prepare(
+      'SELECT username, conversation_id, telegram_user_id FROM users WHERE telegram_user_id = ?',
+    )
+    .bind(telegramUserId)
+    .first<UserRow>();
+}
+
+export async function setConversationId(
+  db: D1Database,
+  username: string,
+  conversationId: string,
+): Promise<void> {
+  await db
+    .prepare('UPDATE users SET conversation_id = ? WHERE username = ?')
+    .bind(conversationId, username)
+    .run();
+}
+
+/**
+ * Backfills the Telegram numeric id for a row that does not have one yet.
+ * Guarded on `telegram_user_id IS NULL` so a re-used id can never silently
+ * overwrite an existing binding, and on the id not already being claimed.
+ */
+export async function backfillTelegramUserId(
+  db: D1Database,
+  username: string,
+  telegramUserId: number,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE users SET telegram_user_id = ?
+       WHERE username = ?
+         AND telegram_user_id IS NULL
+         AND NOT EXISTS (SELECT 1 FROM users WHERE telegram_user_id = ?)`,
+    )
+    .bind(telegramUserId, username, telegramUserId)
+    .run();
+}
+
+/** A user can only be messaged once they have run /start. */
+export function isRegistered(
+  user: UserRow | null,
+): user is UserRow & { conversation_id: string } {
+  return user !== null && user.conversation_id !== null && user.conversation_id !== '';
+}

--- a/worker/domain/amount.ts
+++ b/worker/domain/amount.ts
@@ -1,0 +1,40 @@
+/**
+ * Port of `validate_amount_str` from app/iou/schema.py.
+ *
+ * Python semantics being reproduced:
+ *   - any alphabetic character anywhere -> reject (this is what blocks "inf",
+ *     "nan" and "1e5" from reaching float())
+ *   - keep only digits, '.' and '-'; drop everything else ("$1,234.50" -> "1234.50")
+ *   - float() on the remainder; failure -> reject ("12.34.56" -> reject)
+ *   - non-positive -> reject
+ */
+export class AmountError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AmountError';
+  }
+}
+
+const LETTER = /\p{L}/u;
+const DIGIT = /\p{Nd}/u;
+
+export function validateAmountStr(amount: string): number {
+  if (LETTER.test(amount)) {
+    throw new AmountError(`Amount "${amount}" contains invalid characters`);
+  }
+
+  let cleaned = '';
+  for (const c of amount) {
+    if (DIGIT.test(c) || c === '.' || c === '-') cleaned += c;
+  }
+
+  // Number('') is 0 in JS but float('') raises in Python, so guard explicitly.
+  const value = cleaned === '' ? Number.NaN : Number(cleaned);
+  if (!Number.isFinite(value)) {
+    throw new AmountError(`Unable to parse amount "${amount}"`);
+  }
+  if (value <= 0) {
+    throw new AmountError(`Amount must be positive (got "${amount}")`);
+  }
+  return value;
+}

--- a/worker/domain/balance.ts
+++ b/worker/domain/balance.ts
@@ -1,0 +1,45 @@
+import { round2 } from './money.js';
+
+export interface BalanceEntry {
+  sender: string;
+  recipient: string;
+  amount: number;
+}
+
+export interface IouStatus {
+  owingUser: string;
+  owedUser: string;
+  /** Always non-negative, rounded to 2dp for display. */
+  amount: number;
+}
+
+/**
+ * Port of the inline algorithm in `read_iou_status` (app/iou/views.py:129-160).
+ *
+ * `entries` must already exclude soft-deleted rows. Rows not between the two
+ * users are ignored, mirroring the filtering that `get_entries` applied first.
+ * A sender owes their recipient.
+ */
+export function computeIouStatus(
+  entries: readonly BalanceEntry[],
+  user1: string,
+  user2: string,
+): IouStatus {
+  let totalUser1Owes = 0;
+  let totalUser2Owes = 0;
+
+  for (const entry of entries) {
+    if (entry.sender === user1 && entry.recipient === user2) {
+      totalUser1Owes += entry.amount;
+    } else if (entry.sender === user2 && entry.recipient === user1) {
+      totalUser2Owes += entry.amount;
+    }
+  }
+
+  const difference = totalUser1Owes - totalUser2Owes;
+
+  if (difference >= 0) {
+    return { owingUser: user1, owedUser: user2, amount: round2(difference) };
+  }
+  return { owingUser: user2, owedUser: user1, amount: round2(Math.abs(difference)) };
+}

--- a/worker/domain/format.ts
+++ b/worker/domain/format.ts
@@ -1,0 +1,61 @@
+import { formatMoney } from './money.js';
+
+/** Telegram's per-message character limit. */
+export const MAX_MESSAGE_LENGTH = 4096;
+
+export function chunkText(text: string, size = MAX_MESSAGE_LENGTH): string[] {
+  if (text.length <= size) return [text];
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += size) {
+    chunks.push(text.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export function chunkButtons<T>(buttons: readonly T[], size = 3): T[][] {
+  const rows: T[][] = [];
+  for (let i = 0; i < buttons.length; i += size) {
+    rows.push(buttons.slice(i, i + size));
+  }
+  return rows;
+}
+
+export interface TransactionEntry {
+  sender: string;
+  recipient: string;
+  amount: number;
+  description: string | null;
+  created_at: string;
+}
+
+/** 'YYYY-MM-DD HH:MM:SS' -> 'YYYY-MM-DD', matching TransactionEntry.formatted_date. */
+function formattedDate(createdAt: string): string {
+  if (!createdAt) return '';
+  return createdAt.slice(0, 10);
+}
+
+/** Port of `format_transactions` in bot/main.py. */
+export function formatTransactions(
+  entries: readonly TransactionEntry[],
+  currentUser: string,
+): string {
+  if (entries.length === 0) return 'No transactions found.';
+
+  const sorted = [...entries].sort((a, b) => a.created_at.localeCompare(b.created_at));
+  let result = '📋 Your Transaction History:\n\n';
+
+  sorted.forEach((entry, index) => {
+    const line =
+      entry.sender === currentUser
+        ? `➖ You owe @${entry.recipient} ${formatMoney(entry.amount)}`
+        : `➕ @${entry.sender} owes you ${formatMoney(entry.amount)}`;
+
+    result += `${index + 1}. ${line}\n`;
+    if (entry.description) result += `   📝 ${entry.description}\n`;
+    const date = formattedDate(entry.created_at);
+    if (date) result += `   📅 ${date}\n`;
+    result += '\n';
+  });
+
+  return result;
+}

--- a/worker/domain/money.ts
+++ b/worker/domain/money.ts
@@ -1,0 +1,36 @@
+/**
+ * Amounts are stored as REAL (matching the legacy float behaviour) and only
+ * rounded for display or when a split share is computed.
+ *
+ * Python's round() and format() break exact ties to even. JS Math.round and
+ * toFixed break them away from zero, which would make e.g. a $0.50 split
+ * between 4 people disagree with the legacy backend. round2 reproduces the
+ * Python behaviour.
+ */
+export function round2(value: number): number {
+  const scaled = value * 100;
+  const fraction = Math.abs(scaled % 1);
+  if (fraction === 0.5) {
+    const floor = Math.floor(scaled);
+    return (floor % 2 === 0 ? floor : floor + 1) / 100;
+  }
+  return Math.round(scaled) / 100;
+}
+
+/** Python `f"{value:,.2f}"` -> "1,234.50" */
+export function formatAmount(value: number): string {
+  return round2(value).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+/** Python `f"${value:,.2f}"` -> "$1,234.50" */
+export function formatMoney(value: number): string {
+  return `$${formatAmount(value)}`;
+}
+
+/** Python `f"${value:.2f}"` -> "$1234.50" (no thousands separator) */
+export function formatMoneyPlain(value: number): string {
+  return `$${round2(value).toFixed(2)}`;
+}

--- a/worker/domain/split.ts
+++ b/worker/domain/split.ts
@@ -1,0 +1,58 @@
+import { formatMoneyPlain, round2 } from './money.js';
+
+export class SplitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SplitError';
+  }
+}
+
+export interface SplitEntry {
+  sender: string;
+  recipient: string;
+  amount: number;
+  description: string;
+}
+
+export interface SplitResult {
+  evenShare: number;
+  entries: SplitEntry[];
+}
+
+/**
+ * Port of the `/split` endpoint (app/iou/views.py:162-204).
+ *
+ * The payer counts towards the divisor whenever they appear in `participants`
+ * (the bot always adds them), and only the other participants get an entry —
+ * each of them owes the payer one even share.
+ */
+export function computeSplit(input: {
+  payer: string;
+  amount: number;
+  participants: readonly string[];
+  description: string;
+}): SplitResult {
+  const { payer, amount, participants, description } = input;
+
+  if (participants.length < 2) {
+    throw new SplitError('At least two participants are required for a split.');
+  }
+
+  const evenShare = round2(amount / participants.length);
+  const participantsStr = participants.join(', ');
+  const entryDescription =
+    `Split: ${description} | ` +
+    `Total: ${formatMoneyPlain(amount)} | ` +
+    `Participants: ${participantsStr}`;
+
+  const entries = participants
+    .filter((participant) => participant !== payer)
+    .map((participant) => ({
+      sender: participant,
+      recipient: payer,
+      amount: evenShare,
+      description: entryDescription,
+    }));
+
+  return { evenShare, entries };
+}

--- a/worker/flows/bill.ts
+++ b/worker/flows/bill.ts
@@ -1,0 +1,97 @@
+import { addEntry } from '../db/entries.js';
+import { formatMoney } from '../domain/money.js';
+import {
+  askAmount,
+  conversationIdFor,
+  errorText,
+  listUsernames,
+  trySend,
+  usernameKeyboard,
+  waitForSelection,
+  waitForText,
+} from '../bot/helpers.js';
+import { notRegistered } from '../bot/strings.js';
+import type { ConversationContext, Env, IouConversation } from '../types.js';
+
+export const BILL_CONVERSATION = 'bill';
+const PREFIX = 'BILL_SENDER_';
+
+/** /bill — someone owes me: entry sender = them, recipient = me. */
+export function billFlow(env: Env) {
+  return async function billConversation(
+    conversation: IouConversation,
+    ctx: ConversationContext,
+  ): Promise<void> {
+    const me = ctx.from?.username;
+    const chatId = ctx.chatId;
+    if (me === undefined || chatId === undefined) return;
+
+    const candidates = await conversation.external(() => listUsernames(env.DB, me));
+    if (candidates.length === 0) {
+      await ctx.reply('There is nobody else to bill.');
+      return;
+    }
+
+    const prompt = await ctx.reply('Select the user who owes you:', {
+      reply_markup: usernameKeyboard(candidates, PREFIX, 3),
+    });
+
+    const selection = await waitForSelection(conversation, PREFIX);
+    const sender = selection.value;
+
+    const senderChatId = await conversation.external(() => conversationIdFor(env.DB, sender));
+    if (senderChatId === null) {
+      await selection.ctx.api.sendMessage(chatId, notRegistered(sender));
+      return;
+    }
+
+    await selection.ctx.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiating bill -----\nUser: @${sender}\n\nEnter the amount you want to bill:`,
+    );
+
+    const amount = await askAmount(conversation);
+    await amount.ctx.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiating bill -----\nUser: @${sender}\n` +
+        `Amount: ${amount.raw}\n\nEnter a description:`,
+    );
+
+    const { ctx: last, text: description } = await waitForText(conversation);
+    const amountStr = formatMoney(amount.value);
+
+    try {
+      await conversation.external(() =>
+        addEntry(env.DB, {
+          conversationId: String(chatId),
+          sender,
+          recipient: me,
+          amount: amount.value,
+          description,
+        }),
+      );
+    } catch (error) {
+      console.error({ message: 'bill failed', error: String(error) });
+      await last.reply(errorText(error, '/bill'));
+      return;
+    }
+
+    await last.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiated bill -----\nUser: @${sender}\n` +
+        `Amount: ${amountStr}\nDescription: ${description}`,
+    );
+    await last.api.sendMessage(
+      chatId,
+      `✅ You have billed @${sender} ${amountStr} for ${description}`,
+    );
+    await trySend(
+      last.api,
+      senderChatId,
+      `@${me} billed you ${amountStr} for ${description}`,
+    );
+  };
+}

--- a/worker/flows/query.ts
+++ b/worker/flows/query.ts
@@ -1,0 +1,74 @@
+import { getActiveEntriesBetween } from '../db/entries.js';
+import { computeIouStatus } from '../domain/balance.js';
+import { formatMoney } from '../domain/money.js';
+import {
+  conversationIdFor,
+  listUsernames,
+  usernameKeyboard,
+  waitForSelection,
+} from '../bot/helpers.js';
+import { notRegistered } from '../bot/strings.js';
+import type { ConversationContext, Env, IouConversation } from '../types.js';
+
+export const QUERY_CONVERSATION = 'query';
+const USER1_PREFIX = 'QUERY_USER1_';
+const USER2_PREFIX = 'QUERY_USER2_';
+
+/** /query — net balance between any two authorized users. */
+export function queryFlow(env: Env) {
+  return async function queryConversation(
+    conversation: IouConversation,
+    ctx: ConversationContext,
+  ): Promise<void> {
+    const chatId = ctx.chatId;
+    if (chatId === undefined) return;
+
+    const everyone = await conversation.external(() => listUsernames(env.DB));
+    if (everyone.length < 2) {
+      await ctx.reply('There are not enough users to query.');
+      return;
+    }
+
+    await ctx.reply('Query: Select the first user:', {
+      reply_markup: usernameKeyboard(everyone, USER1_PREFIX, everyone.length),
+    });
+
+    const first = await waitForSelection(conversation, USER1_PREFIX);
+    const user1 = first.value;
+
+    const user1ChatId = await conversation.external(() => conversationIdFor(env.DB, user1));
+    if (user1ChatId === null) {
+      await first.ctx.api.sendMessage(chatId, notRegistered(user1));
+      return;
+    }
+
+    const remaining = everyone.filter((username) => username !== user1);
+    await first.ctx.editMessageText(`First user: @${user1}. Now select the second user:`, {
+      reply_markup: usernameKeyboard(remaining, USER2_PREFIX, 3),
+    });
+
+    const second = await waitForSelection(conversation, USER2_PREFIX);
+    const user2 = second.value;
+
+    const user2ChatId = await conversation.external(() => conversationIdFor(env.DB, user2));
+    if (user2ChatId === null) {
+      await second.ctx.api.sendMessage(chatId, notRegistered(user2));
+      return;
+    }
+
+    try {
+      const entries = await conversation.external(() =>
+        getActiveEntriesBetween(env.DB, user1, user2),
+      );
+      const status = computeIouStatus(entries, user1, user2);
+      await second.ctx.editMessageText(
+        `@${status.owingUser} owes @${status.owedUser} ${formatMoney(status.amount)}`,
+      );
+    } catch (error) {
+      console.error({ message: 'query failed', error: String(error) });
+      await second.ctx.editMessageText(
+        `❌ Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+}

--- a/worker/flows/send.ts
+++ b/worker/flows/send.ts
@@ -1,0 +1,99 @@
+import { addEntry } from '../db/entries.js';
+import { formatMoney } from '../domain/money.js';
+import {
+  askAmount,
+  conversationIdFor,
+  errorText,
+  listUsernames,
+  trySend,
+  usernameKeyboard,
+  waitForSelection,
+  waitForText,
+} from '../bot/helpers.js';
+import { notRegistered } from '../bot/strings.js';
+import type { ConversationContext, Env, IouConversation } from '../types.js';
+
+export const SEND_CONVERSATION = 'send';
+const PREFIX = 'SEND_RECIPIENT_';
+
+/** /send — I hand someone an IOU: entry sender = me, recipient = them. */
+export function sendFlow(env: Env) {
+  return async function sendConversation(
+    conversation: IouConversation,
+    ctx: ConversationContext,
+  ): Promise<void> {
+    const me = ctx.from?.username;
+    const chatId = ctx.chatId;
+    if (me === undefined || chatId === undefined) return;
+
+    const candidates = await conversation.external(() => listUsernames(env.DB, me));
+    if (candidates.length === 0) {
+      await ctx.reply('There is nobody else to send to.');
+      return;
+    }
+
+    const prompt = await ctx.reply('Select a recipient:', {
+      reply_markup: usernameKeyboard(candidates, PREFIX, 3),
+    });
+
+    const selection = await waitForSelection(conversation, PREFIX);
+    const recipient = selection.value;
+
+    const recipientChatId = await conversation.external(() =>
+      conversationIdFor(env.DB, recipient),
+    );
+    if (recipientChatId === null) {
+      await selection.ctx.api.sendMessage(chatId, notRegistered(recipient, 'Recipient'));
+      return;
+    }
+
+    await selection.ctx.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiating send -----\nRecipient: @${recipient}\n\nEnter the amount you want to send:`,
+    );
+
+    const amount = await askAmount(conversation);
+    await amount.ctx.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiating send -----\nRecipient: @${recipient}\n` +
+        `Amount: ${amount.raw}\n\nEnter a description:`,
+    );
+
+    const { ctx: last, text: description } = await waitForText(conversation);
+    const amountStr = formatMoney(amount.value);
+
+    try {
+      await conversation.external(() =>
+        addEntry(env.DB, {
+          conversationId: String(chatId),
+          sender: me,
+          recipient,
+          amount: amount.value,
+          description,
+        }),
+      );
+    } catch (error) {
+      console.error({ message: 'send failed', error: String(error) });
+      await last.reply(errorText(error, '/send'));
+      return;
+    }
+
+    await last.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiated send -----\nRecipient: @${recipient}\n` +
+        `Amount: ${amountStr}\nDescription: ${description}`,
+    );
+    await last.api.sendMessage(
+      chatId,
+      `✅ You sent @${recipient} ${amountStr} for ${description}`,
+    );
+    await trySend(
+      last.api,
+      recipientChatId,
+      `@${me} sent you ${amountStr} for ${description}`,
+    );
+  };
+}

--- a/worker/flows/settle.ts
+++ b/worker/flows/settle.ts
@@ -1,0 +1,113 @@
+import { InlineKeyboard } from 'grammy';
+import { getActiveEntriesBetween, settleBetween } from '../db/entries.js';
+import { computeIouStatus } from '../domain/balance.js';
+import { formatMoney } from '../domain/money.js';
+import {
+  conversationIdFor,
+  listUsernames,
+  trySend,
+  usernameKeyboard,
+  waitForSelection,
+} from '../bot/helpers.js';
+import { notRegistered } from '../bot/strings.js';
+import type { ConversationContext, Env, IouConversation } from '../types.js';
+
+export const SETTLE_CONVERSATION = 'settle';
+const USER_PREFIX = 'SETTLE_USER_';
+const CONFIRM_PREFIX = 'SETTLE_CONFIRM_';
+
+/** /settle — soft-delete every active entry between the caller and another user. */
+export function settleFlow(env: Env) {
+  return async function settleConversation(
+    conversation: IouConversation,
+    ctx: ConversationContext,
+  ): Promise<void> {
+    const me = ctx.from?.username;
+    const chatId = ctx.chatId;
+    if (me === undefined || chatId === undefined) return;
+
+    const candidates = await conversation.external(() => listUsernames(env.DB, me));
+    if (candidates.length === 0) {
+      await ctx.reply('There is nobody else to settle with.');
+      return;
+    }
+
+    await ctx.reply('Select the user you want to settle with:', {
+      reply_markup: usernameKeyboard(candidates, USER_PREFIX, 3),
+    });
+
+    const selection = await waitForSelection(conversation, USER_PREFIX);
+    const otherUser = selection.value;
+
+    const otherChatId = await conversation.external(() => conversationIdFor(env.DB, otherUser));
+    if (otherChatId === null) {
+      await selection.ctx.api.sendMessage(chatId, notRegistered(otherUser));
+      return;
+    }
+
+    const entries = await conversation.external(() =>
+      getActiveEntriesBetween(env.DB, me, otherUser),
+    );
+    const status = computeIouStatus(entries, me, otherUser);
+
+    if (status.amount === 0) {
+      await selection.ctx.editMessageText(
+        `No outstanding transactions between you and @${otherUser} to settle.`,
+      );
+      return;
+    }
+
+    const amountStr = formatMoney(status.amount);
+    await selection.ctx.editMessageText(
+      `💰 Settlement Summary:\n\n` +
+        `@${status.owingUser} owes @${status.owedUser} ${amountStr}\n\n` +
+        `Are you sure you want to settle all transactions between you and @${otherUser}? ` +
+        `This will erase all transaction history between you.`,
+      {
+        reply_markup: InlineKeyboard.from([
+          [
+            InlineKeyboard.text('✅ Yes, settle', `${CONFIRM_PREFIX}YES`),
+            InlineKeyboard.text('❌ No, cancel', `${CONFIRM_PREFIX}NO`),
+          ],
+        ]),
+      },
+    );
+
+    const confirmation = await waitForSelection(conversation, CONFIRM_PREFIX);
+    if (confirmation.value !== 'YES') {
+      await confirmation.ctx.editMessageText('Settlement cancelled.');
+      return;
+    }
+
+    let settled = 0;
+    try {
+      settled = await conversation.external(() => settleBetween(env.DB, me, otherUser));
+    } catch (error) {
+      console.error({ message: 'settle failed', error: String(error) });
+      await confirmation.ctx.editMessageText(
+        `❌ Error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return;
+    }
+
+    if (settled === 0) {
+      await confirmation.ctx.editMessageText(
+        `No transactions were found to settle between ${me} and ${otherUser}`,
+      );
+      return;
+    }
+
+    await confirmation.ctx.editMessageText(
+      `✅ Settlement completed!\n\n` +
+        `${settled} transaction(s) totaling ${amountStr} have been settled ` +
+        `between you and @${otherUser}.`,
+    );
+    await trySend(
+      confirmation.ctx.api,
+      otherChatId,
+      `✅ Settlement completed!\n\n` +
+        `@${me} has settled ${settled} transaction(s) totaling ${amountStr} ` +
+        `between you. All transaction history has been cleared.`,
+    );
+  };
+}

--- a/worker/flows/split.ts
+++ b/worker/flows/split.ts
@@ -1,0 +1,211 @@
+import { InlineKeyboard } from 'grammy';
+import { addEntries } from '../db/entries.js';
+import { chunkButtons } from '../domain/format.js';
+import { formatMoney } from '../domain/money.js';
+import { computeSplit } from '../domain/split.js';
+import {
+  askAmount,
+  conversationIdFor,
+  conversationIdsFor,
+  errorText,
+  listUsernames,
+  trySend,
+  usernameKeyboard,
+  waitForSelection,
+  waitForText,
+} from '../bot/helpers.js';
+import { notRegistered } from '../bot/strings.js';
+import type { ConversationContext, Env, IouConversation } from '../types.js';
+
+export const SPLIT_CONVERSATION = 'split';
+const PAYER_PREFIX = 'SPLIT_PAYER_';
+const PARTICIPANT_PREFIX = 'SPLIT_PART_';
+const TOGGLE = 'TOGGLE_';
+const DONE = 'DONE';
+
+function participantsKeyboard(
+  everyone: readonly string[],
+  selected: ReadonlySet<string>,
+): InlineKeyboard {
+  const rows = chunkButtons(everyone, everyone.length).map((row) =>
+    row.map((username) =>
+      InlineKeyboard.text(
+        `${selected.has(username) ? '✅' : '⬜'} ${username}`,
+        `${PARTICIPANT_PREFIX}${TOGGLE}${username}`,
+      ),
+    ),
+  );
+  rows.push([InlineKeyboard.text('Done', `${PARTICIPANT_PREFIX}${DONE}`)]);
+  return InlineKeyboard.from(rows);
+}
+
+function participantsPrompt(selected: ReadonlySet<string>): string {
+  const list = [...selected].map((username) => `@${username}`).join(', ');
+  return `Select participants (toggle by tapping). Currently selected:\n${list === '' ? '(none)' : list}`;
+}
+
+/** /split — divide an amount evenly; everyone but the payer owes the payer a share. */
+export function splitFlow(env: Env) {
+  return async function splitConversation(
+    conversation: IouConversation,
+    ctx: ConversationContext,
+  ): Promise<void> {
+    const me = ctx.from?.username;
+    const chatId = ctx.chatId;
+    if (me === undefined || chatId === undefined) return;
+
+    const everyone = await conversation.external(() => listUsernames(env.DB));
+    if (everyone.length < 2) {
+      await ctx.reply('There are not enough users to split with.');
+      return;
+    }
+
+    const prompt = await ctx.reply('Select who paid the bill:', {
+      reply_markup: usernameKeyboard(everyone, PAYER_PREFIX, everyone.length),
+    });
+
+    const payerSelection = await waitForSelection(conversation, PAYER_PREFIX);
+    const payer = payerSelection.value;
+
+    const payerChatId = await conversation.external(() => conversationIdFor(env.DB, payer));
+    if (payerChatId === null) {
+      await payerSelection.ctx.api.sendMessage(chatId, notRegistered(payer, 'Payer'));
+      return;
+    }
+
+    await payerSelection.ctx.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiating split -----\nPayer: @${payer}\n\nEnter the amount:`,
+    );
+
+    const amount = await askAmount(conversation);
+    await amount.ctx.api.editMessageText(
+      chatId,
+      prompt.message_id,
+      `----- Initiating split -----\nPayer: @${payer}\n` +
+        `Amount: ${amount.raw}\n\nEnter a description:`,
+    );
+
+    const { ctx: describeCtx, text: description } = await waitForText(conversation);
+
+    // The initiator and the payer always start selected, as in the legacy bot.
+    const selected = new Set<string>([me, payer]);
+    const picker = await describeCtx.reply(participantsPrompt(selected), {
+      reply_markup: participantsKeyboard(everyone, selected),
+    });
+
+    let doneCtx: ConversationContext;
+    for (;;) {
+      const action = await waitForSelection(conversation, PARTICIPANT_PREFIX);
+      if (action.value === DONE) {
+        doneCtx = action.ctx;
+        break;
+      }
+
+      const username = action.value.slice(TOGGLE.length);
+      if (!everyone.includes(username)) continue;
+
+      const registered = await conversation.external(() => conversationIdFor(env.DB, username));
+      if (registered === null) {
+        await action.ctx.api.sendMessage(chatId, notRegistered(username));
+        continue;
+      }
+
+      if (username === payer && selected.has(username)) {
+        await action.ctx.api.sendMessage(
+          chatId,
+          `The payer @${payer} cannot be removed from the split.`,
+        );
+        continue;
+      }
+
+      if (selected.has(username)) {
+        selected.delete(username);
+        if (username === me) {
+          await action.ctx.api.sendMessage(
+            chatId,
+            "Heads up: You've removed yourself from the split. Did you mean to do that? " +
+              'You can re-select yourself if this was accidental.',
+          );
+        }
+      } else {
+        selected.add(username);
+      }
+
+      await action.ctx.api.editMessageText(
+        chatId,
+        picker.message_id,
+        participantsPrompt(selected),
+        { reply_markup: participantsKeyboard(everyone, selected) },
+      );
+    }
+
+    // Canonical ordering keeps the stored description stable run to run.
+    const participants = everyone.filter((username) => selected.has(username));
+
+    const chatIds = await conversation.external(() => conversationIdsFor(env.DB, participants));
+    const unregistered = participants.filter((username) => chatIds[username] === null);
+    if (unregistered.length > 0) {
+      await doneCtx.editMessageText(
+        'The following users are not registered: ' +
+          unregistered.map((username) => `@${username}`).join(', ') +
+          '. They need to /start the bot first.',
+      );
+      return;
+    }
+
+    try {
+      const result = computeSplit({
+        payer,
+        amount: amount.value,
+        participants,
+        description,
+      });
+
+      await conversation.external(() =>
+        addEntries(
+          env.DB,
+          result.entries.map((entry) => ({
+            conversationId: String(chatId),
+            sender: entry.sender,
+            recipient: entry.recipient,
+            amount: entry.amount,
+            description: entry.description,
+          })),
+        ),
+      );
+
+      const amountStr = formatMoney(amount.value);
+      const shareStr = formatMoney(result.evenShare);
+      const participantsText = participants.map((username) => `@${username}`).join(', ');
+
+      await doneCtx.api.editMessageText(
+        chatId,
+        prompt.message_id,
+        `----- Initiated split -----\nPayer: @${payer}\n` +
+          `Amount: ${amountStr}\nDescription: ${description}\n` +
+          `Participants: ${participantsText}`,
+      );
+      await doneCtx.editMessageText('✅ Split successful!');
+
+      const notification =
+        `💳 @${me} split a transaction!\n` +
+        `Payer: @${payer}\n` +
+        `Total amount: ${amountStr}\n` +
+        `Split portion: ${shareStr}\n` +
+        `Description: ${description}\n` +
+        `Participants: ${participantsText}`;
+
+      for (const username of participants) {
+        const target = chatIds[username];
+        if (target !== null && target !== undefined) {
+          await trySend(doneCtx.api, target, notification);
+        }
+      }
+    } catch (error) {
+      console.error({ message: 'split failed', error: String(error) });
+      await doneCtx.editMessageText(errorText(error, '/split'));
+    }
+  };
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,67 @@
+import { webhookCallback } from 'grammy';
+import { createBot } from './bot/index.js';
+import { WEBHOOK_PATH } from './webhookPath.js';
+import { VERSION } from './version.js';
+import type { Env } from './types.js';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Constant-time string comparison. A plain `===` would leak how many leading
+ * characters of the webhook secret an attacker has guessed.
+ */
+function secretsMatch(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const left = encoder.encode(a);
+  const right = encoder.encode(b);
+  if (left.byteLength !== right.byteLength) return false;
+  return crypto.subtle.timingSafeEqual(left, right);
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/healthcheck') {
+      return json({ status: 'ok', version: VERSION });
+    }
+
+    if (url.pathname !== WEBHOOK_PATH) {
+      return new Response('Not found', { status: 404 });
+    }
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+
+    // Knowing the URL is not enough: Telegram echoes back a shared secret that
+    // was registered with setWebhook, and anything else is rejected outright.
+    const presented = request.headers.get('X-Telegram-Bot-Api-Secret-Token');
+    const expected = env.TELEGRAM_WEBHOOK_SECRET;
+    if (
+      typeof expected !== 'string' ||
+      expected === '' ||
+      presented === null ||
+      !secretsMatch(presented, expected)
+    ) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    try {
+      const bot = await createBot(env);
+      return await webhookCallback(bot, 'cloudflare-mod', {
+        secretToken: expected,
+        onTimeout: 'return',
+      })(request);
+    } catch (error) {
+      // Telegram retries on a non-2xx, which would replay a partially applied
+      // update, so log and acknowledge instead.
+      console.error({ message: 'webhook handling failed', error: String(error) });
+      return new Response('ok');
+    }
+  },
+} satisfies ExportedHandler<Env>;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,4 +1,5 @@
-import { webhookCallback } from 'grammy';
+import { BotError, webhookCallback } from 'grammy';
+import type { Context } from 'grammy';
 import { createBot } from './bot/index.js';
 import { WEBHOOK_PATH } from './webhookPath.js';
 import { VERSION } from './version.js';
@@ -9,6 +10,48 @@ function json(body: unknown, status = 200): Response {
     status,
     headers: { 'content-type': 'application/json' },
   });
+}
+
+const SOMETHING_WENT_WRONG =
+  '❌ Something went wrong. If you were in the middle of a guided flow it has ' +
+  'been cancelled — please start it again.';
+
+/** What the user was doing, so a failure is traceable to a command. */
+function describeAction(ctx: Context): string {
+  const text = ctx.message?.text;
+  if (text !== undefined) return text.split(/\s/)[0] ?? 'message';
+  const data = ctx.callbackQuery?.data;
+  if (data !== undefined) return `callback:${data}`;
+  return 'update';
+}
+
+/**
+ * Middleware errors surface here rather than through `bot.catch`: grammY only
+ * consults its error handler from the polling loop, and `webhookCallback` goes
+ * through `bot.handleUpdate`, which rethrows as a BotError.
+ *
+ * An error escaping a conversation makes the plugin discard its state, so the
+ * user's half-finished flow is gone. Saying so beats leaving them staring at a
+ * prompt that will never respond.
+ */
+async function handleBotError(error: BotError<Context>): Promise<void> {
+  const ctx = error.ctx;
+  console.error({
+    message: 'update handling failed',
+    update_id: ctx?.update?.update_id,
+    chat_id: ctx?.chat?.id,
+    username: ctx?.from?.username,
+    action: ctx === undefined ? 'unknown' : describeAction(ctx),
+    error: String(error.error),
+  });
+
+  // Best effort: whatever broke the update is quite likely to break this too.
+  if (ctx?.chat === undefined) return;
+  try {
+    await ctx.reply(SOMETHING_WENT_WRONG);
+  } catch (replyError) {
+    console.error({ message: 'could not report failure', error: String(replyError) });
+  }
 }
 
 /**
@@ -51,6 +94,8 @@ export default {
       return new Response('Unauthorized', { status: 401 });
     }
 
+    // Telegram retries on a non-2xx, which would replay a partially applied
+    // update, so every failure below is logged and then acknowledged.
     try {
       const bot = await createBot(env);
       return await webhookCallback(bot, 'cloudflare-mod', {
@@ -58,9 +103,11 @@ export default {
         onTimeout: 'return',
       })(request);
     } catch (error) {
-      // Telegram retries on a non-2xx, which would replay a partially applied
-      // update, so log and acknowledge instead.
-      console.error({ message: 'webhook handling failed', error: String(error) });
+      if (error instanceof BotError) {
+        await handleBotError(error);
+      } else {
+        console.error({ message: 'webhook handling failed', error: String(error) });
+      }
       return new Response('ok');
     }
   },

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -1,0 +1,26 @@
+import type { Context } from 'grammy';
+import type { Conversation, ConversationFlavor } from '@grammyjs/conversations';
+import type { UserRow } from './db/users.js';
+
+export interface Env {
+  DB: D1Database;
+  TELEGRAM_BOT_TOKEN: string;
+  TELEGRAM_WEBHOOK_SECRET: string;
+}
+
+/** Set by the authorization middleware before any handler runs. */
+export interface IouFlavor {
+  iouUser: UserRow;
+}
+
+/** Context in the outer middleware tree. */
+export type BotContext = ConversationFlavor<Context & IouFlavor>;
+
+/**
+ * Context inside a conversation. The conversations plugin builds these from
+ * scratch on every replay, so they carry no properties added by the outer
+ * middleware — flows read the database through `conversation.external` instead.
+ */
+export type ConversationContext = Context;
+
+export type IouConversation = Conversation<BotContext, ConversationContext>;

--- a/worker/version.ts
+++ b/worker/version.ts
@@ -1,0 +1,4 @@
+import pkg from '../package.json' with { type: 'json' };
+
+/** Inlined at bundle time so /version needs no network or filesystem access. */
+export const VERSION: string = pkg.version;

--- a/worker/webhookPath.ts
+++ b/worker/webhookPath.ts
@@ -1,0 +1,6 @@
+/**
+ * The only public route besides /healthcheck. The random segment keeps the
+ * endpoint from being discoverable; the secret-token header is what actually
+ * authenticates a request. Changing this requires re-running setWebhook.
+ */
+export const WEBHOOK_PATH = '/telegram/494e082e23b910f6e23630bf9626faf1';

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,20 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "iou-app",
+  "main": "worker/index.ts",
+  "compatibility_date": "2026-08-08",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "iou-app",
+      "database_id": "TBD",
+      "migrations_dir": "migrations"
+    }
+  ]
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     {
       "binding": "DB",
       "database_name": "iou-app",
-      "database_id": "TBD",
+      "database_id": "fa83c33d-f0ab-47e4-a916-82a06ef5c547",
       "migrations_dir": "migrations"
     }
   ]


### PR DESCRIPTION
## Summary

Full migration off the Raspberry Pi + DynamoDB stack onto Cloudflare Workers + D1:

- **TypeScript Worker** (grammY) replaces the Python FastAPI app + polling bot. Single worker, bot-only surface: a secret-path Telegram webhook (verified via `X-Telegram-Bot-Api-Secret-Token`) and an unauthenticated `/healthcheck`. Nothing else exposed.
- **D1 database** `iou-app` with `wrangler d1 migrations`. All 112 legacy entries (23 active) + 5 users imported; legacy string-typed `amount`/`deleted` normalized to REAL/INTEGER. Balance cross-check matches legacy exactly ($187.98 skycarl→rigels).
- **Webhook mode** replaces polling; the 5 guided flows (`/send`, `/bill`, `/query`, `/split`, `/settle`) persist conversation state in D1 (no long-lived process needed). Added `/cancel`, per-chat+per-user session keying, an impersonation guard (username match refused if a bound `telegram_user_id` mismatches), and half-to-even money rounding to match Python.
- **Auth**: only the 5 migrated users are recognized; everyone else gets a single refusal, fail-closed on DB errors.
- **CI/CD**: `.github/workflows/deploy.yml` — typecheck + vitest (64 tests) then `wrangler deploy` with D1 migrations applied on each deploy.

Legacy Python is intentionally untouched in this PR; it gets removed in a follow-up once e2e verification is signed off.

## Status

Already deployed and cut over: webhook live at the workers.dev URL, Pi bot container stopped. Requires repo secret `CLOUDFLARE_API_TOKEN` (Workers Edit + D1 Edit) before merging so the deploy workflow can run.

## Test plan

- 64 vitest tests: balance/split/settle parity vs legacy Python, amount parsing, webhook auth, allowlist + impersonation, all 5 flows driven end-to-end through the real bundle + D1 session store, mid-flow Telegram-API-failure handling
- Live verification against the deployed worker: commands, auth rejection, session lifecycle, data integrity (baseline balances byte-identical after testing)
- Remaining: manual Telegram tap-through of the inline-button flows (skycarl/rigels with `[MIGRATION-TEST]` descriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)