### PR TITLE
Bump deploy workflow actions (checkout v7, setup-node v7, wrangler-action v4)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -38,14 +38,14 @@ jobs:
 
       # Schema first: the Worker deployed below expects the migrated tables.
       - name: Apply D1 migrations
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: d1 migrations apply iou-app --remote
 
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Supersedes Dependabot PRs #78, #79, #80 in a single commit: `actions/checkout` v4→v7, `actions/setup-node` v4→v7, `cloudflare/wrangler-action` v3→v4. Originally pushed to #77 but landed after its merge, so it needed its own PR. Dependabot should auto-close its PRs once this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)